### PR TITLE
Release v2.0.0 semantic reliability

### DIFF
--- a/.agent_rules/README.md
+++ b/.agent_rules/README.md
@@ -90,4 +90,4 @@ uv pip install -e .                   # Install deps
 
 ---
 
-**Pipeline Version**: 1.9.0 | **Steps**: 25 | **Tests**: latest recorded full suite with Ollama integration excludes: 2,381 passed, 17 skipped, 1 xfailed; collect-only inventory is 2,399 tests | **MCP Tools**: verify with `src/tests/mcp/test_mcp_audit.py`
+**Pipeline Version**: 2.0.0 | **Steps**: 25 | **Tests**: latest recorded full suite with Ollama integration excludes: 2,393 passed, 17 skipped, 1 xfailed; collect-only inventory is 2,411 tests | **MCP Tools**: verify with `src/tests/mcp/test_mcp_audit.py`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 This guide details the architecture of the Generalized Notation Notation (GNN) system. It complements `DOCS.md` and `doc/pipeline/README.md` with an implementation-oriented perspective for developers.
 
 **Last Updated**: 2026-06-12
-**Version**: 1.9.0
+**Version**: 2.0.0
 **Status**: Maintained
 **Pipeline Steps**: 25 (0-24)
 
@@ -323,7 +323,7 @@ Each agent implements comprehensive performance monitoring:
 
 ---
 
-**Architecture Version**: 1.9.0
+**Architecture Version**: 2.0.0
 **Last Updated**: 2026-06-12
 **Status**: ✅ Production Ready
 **Compliance**: Thin orchestrator pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ No unreleased changes yet.
 
 ---
 
+## [2.0.0] — 2026-06-12
+
+### Added
+- **Semantic fidelity release gate**: `scripts/run_semantic_fidelity_gate.py` writes `gnn_semantic_fidelity_ledger_v1` artifacts for maintained model families.
+- **Strict semantic contracts**: representative fixtures now preserve model identity, variables, edges, dimensions, parameter shapes, equations, time, and ontology mappings across JSON parse/serialize/parse checks.
+- **Cross-framework reliability release gate**: `scripts/run_cross_framework_reliability.py` writes `gnn_cross_framework_reliability_ledger_v1` artifacts with compatible, required, and unsupported backend statuses.
+- **GridWorld three-backend comparison**: GridWorld is profiled for PyMDP, RxInfer, and ActiveInference.jl, including seed, trace length, matrix-shape, and matrix-provenance parity.
+
+### Changed
+- GridWorld model-family acceptance now requests PyMDP, RxInfer, and ActiveInference.jl for the v2 comparison fixture instead of a PyMDP-only profile.
+- Roadmap next target moves to v3.0.0 for durable streams, long-running sessions, and auditable container plans.
+
+### Fixed
+- JSON serialization now emits equation objects instead of lossy stringified dataclasses, preventing silent semantic round-trip drift.
+- Cross-framework reliability no longer certifies aggregate Step 12 success without successful non-skipped execution-detail rows and current simulation payloads for required backends.
+
+---
+
 ## [1.9.0] — 2026-06-12
 
 ### Added
@@ -149,7 +167,8 @@ No unreleased changes yet.
 - pytest test suite with comprehensive coverage
 - MCP tool registration framework
 
-[Unreleased]: https://github.com/ActiveInferenceInstitute/GeneralizedNotationNotation/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/ActiveInferenceInstitute/GeneralizedNotationNotation/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/ActiveInferenceInstitute/GeneralizedNotationNotation/compare/v1.9.0...v2.0.0
 [1.9.0]: https://github.com/ActiveInferenceInstitute/GeneralizedNotationNotation/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/ActiveInferenceInstitute/GeneralizedNotationNotation/compare/v1.6.0...v1.8.0
 [1.6.0]: https://github.com/ActiveInferenceInstitute/GeneralizedNotationNotation/compare/v1.3.0...v1.6.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
     # This entry acknowledges all contributors. Individual contributors can be listed above if desired.
 
 title: "GeneralizedNotationNotation (GNN)"
-version: 1.9.0 # Current stable release
+version: 2.0.0 # Current stable release
 date-released: 2026-06-12
 
 abstract: |

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@
 
 **Smékal, J., & Friedman, D. A. (2023)**. *Generalized Notation Notation for Active Inference Models*. Active Inference Journal.  
 **Last Updated**: 2026-06-12
-**Version**: 1.9.0
+**Version**: 2.0.0
 **Status**: ✅ Production Ready (Active Inference Institute)  
-**Test Suite Inventory (measured 2026-06-12)**: 184 `test_*.py` files under `src/tests/`; `uv run --extra dev python -m pytest --collect-only src/tests/ -q --tb=no --ignore=src/tests/llm/test_llm_ollama.py --ignore=src/tests/llm/test_llm_ollama_integration.py` collected 2,399 tests. Latest recorded full suite evidence with the same Ollama integration excludes is 2,381 passed, 17 skipped, 1 xfailed.
-**Features (v1.9.0)**: model-family acceptance and interpretability ledgers for basics, discrete, continuous, hierarchical, multi-agent, precision, structured, gridworld, and scaling-study fixtures; explicit profiled unsupported Step 11/12 skips for continuous/hierarchical families; maintained template CLI (`gnn templates list`, `gnn templates show`, `gnn pull`); packaged template assets with checksum/collision handling; authenticated local MCP HTTP orchestration; pre-commit/devcontainer tooling; structured PyMDP 1.0 POMDP execution; PyMDP Scaling Study; and MCP Full Module Exposure.
-**Next Target**: v2.0.0 semantic fidelity and cross-framework reliability hardening.
+**Test Suite Inventory (measured 2026-06-12)**: 186 `test_*.py` files under `src/tests/`; `uv run --extra dev python -m pytest --collect-only src/tests/ -q --tb=no --ignore=src/tests/llm/test_llm_ollama.py --ignore=src/tests/llm/test_llm_ollama_integration.py` collected 2,411 tests. Latest recorded full suite evidence with the same Ollama integration excludes is 2,393 passed, 17 skipped, 1 xfailed.
+**Features (v2.0.0)**: semantic fidelity ledgers across all maintained model families, strict JSON parse/serialize/parse preservation for variables, edges, dimensions, parameter shapes, equations, time, and ontology mappings; cross-framework reliability ledgers with explicit compatible/unsupported backend statuses; GridWorld comparison across PyMDP, RxInfer, and ActiveInference.jl; model-family acceptance and interpretability ledgers; maintained template CLI (`gnn templates list`, `gnn templates show`, `gnn pull`); authenticated local MCP HTTP orchestration; structured PyMDP 1.0 POMDP execution; PyMDP Scaling Study; and MCP Full Module Exposure.
+**Next Target**: v3.0.0 long-running orchestration, durable observation streams, and auditable container plans.
 📖 **DOI:** [10.5281/zenodo.7803328](https://doi.org/10.5281/zenodo.7803328)  
 📁 **Archive:** [zenodo.org/records/7803328](https://zenodo.org/records/7803328)
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -1,20 +1,11 @@
 # TO-DO — GNN Pipeline Roadmap
 
 **Last Updated**: 2026-06-12
-**Current Version**: 1.9.0
-**Next Target**: v2.0.0 (semantic fidelity and cross-framework reliability)
+**Current Version**: 2.0.0
+**Next Target**: v3.0.0 (long-running orchestration, durable streams, and auditable container plans)
 
-**Current Evidence (2026-06-12)**: v1.9.0 focused family/report suite
-`17 passed`; command-of-record collect-only inventory is `2399` collected tests
-across 184 `test_*.py` files with the documented Ollama integration ignores.
-Latest full local suite evidence with the same Ollama ignores is
-`2381 passed, 17 skipped, 1 xfailed`. The all-family strict acceptance passed
-for 9 families; continuous/hierarchical Step 11/12 recorded as profiled
-unsupported skips with `0` raw failed Step 11/12 counts. v1.8.0 focused
-release smokes passed for `gnn templates list`, `gnn templates show
-pomdp-gridworld-3x3`, dry-run `gnn pull` to `/tmp/gnn-pull`, and authenticated
-MCP HTTP tests (`12 passed`; combined CLI/MCP/capability suite `32 passed`);
-`just lint` passes.
+**Current Evidence (2026-06-12)**: v2.0.0 semantic fidelity gate passed for 9 families (`gnn_semantic_fidelity_ledger_v1`); cross-framework reliability gate passed for 9 families (`gnn_cross_framework_reliability_ledger_v1`) with GridWorld compared PyMDP, RxInfer, and ActiveInference.jl and all other unprofiled backends recorded with explicit unsupported statuses. Command-of-record collect-only inventory is `2411` collected tests across 186 `test_*.py` files with the documented Ollama integration ignores. Latest full local suite evidence with the same Ollama ignores is `2393 passed, 17 skipped, 1 xfailed`. v1.9 all-family strict acceptance remains green for 9 families; continuous and hierarchical Step 11/12 remain profiled unsupported skips with `0` raw failed Step 11/12 counts. v1.8.0 focused release smokes passed for `gnn templates list`, `gnn templates show pomdp-gridworld-3x3`, dry-run `gnn pull` to `/tmp/gnn-pull`, and authenticated
+MCP HTTP tests (`12 passed`; combined CLI/MCP/capability suite `32 passed`); `just lint` passes.
 
 ---
 
@@ -111,12 +102,21 @@ uv run --extra dev python src/main.py --target-dir input/gnn_files/discrete --ou
 
 ---
 
-## 🧪 v2.0.0 — Semantic Fidelity & Cross-Framework Reliability
+## ✅ v2.0.0 — Semantic Fidelity & Cross-Framework Reliability (Released)
 
 > **Scope**: Upgrade GNN from broad fixture acceptance to stronger semantic preservation, cross-format round trips, and cross-framework equivalence checks.
+> **Released**: 2026-06-12 (tag: `v2.0.0`)
 
-- [ ] **Semantic Round-Trip Gates** — Require representative model families to preserve variables, edges, dimensions, and key matrix contracts across maintained formats.
-- [ ] **Cross-Framework Result Comparisons** — Compare compatible PyMDP, RxInfer, JAX, NumPyro, PyTorch, ActiveInference.jl, and DisCoPy outputs with explicit skipped/failed states for unavailable frameworks.
+- [x] **Semantic Round-Trip Gates** — Require representative model families to preserve variables, edges, dimensions, parameter shapes, equations, time, and ontology mappings across the maintained strict JSON interchange path. `scripts/run_semantic_fidelity_gate.py` passed for all 9 manifest families and wrote `gnn_semantic_fidelity_ledger_v1` artifacts.
+- [x] **Cross-Framework Result Comparisons** — Compare compatible backend outputs through `scripts/run_cross_framework_reliability.py`; required backends need Step 11/12 evidence, successful non-skipped Step 12 execution detail rows, current simulation payloads, matching seeds when present, trace lengths, and matrix-shape/provenance parity. The all-family gate passed for 9 families; GridWorld compared PyMDP, RxInfer, and ActiveInference.jl, while JAX, NumPyro, PyTorch, and DisCoPy remain explicit unsupported statuses unless profiled for a compatible family.
+
+### Acceptance
+```bash
+uv run --extra dev python -m pytest src/tests/pipeline/test_semantic_fidelity_gate.py src/tests/pipeline/test_cross_framework_reliability.py -q
+uv run --extra dev python scripts/run_semantic_fidelity_gate.py --manifest input/model_family_manifest.json --output-dir /tmp/gnn-semantic-fidelity --strict
+uv run --extra dev python scripts/run_cross_framework_reliability.py --manifest input/model_family_manifest.json --output-dir /tmp/gnn-cross-framework --strict
+uv run --extra dev python scripts/run_model_family_acceptance.py --manifest input/model_family_manifest.json --output-dir /tmp/gnn-family-acceptance-all --strict
+```
 
 ---
 

--- a/input/model_family_manifest.json
+++ b/input/model_family_manifest.json
@@ -75,7 +75,7 @@
       "name": "gridworld",
       "description": "Gridworld POMDP fixture used for cross-framework acceptance checks.",
       "target_dir": "input/gnn_files/pomdp_gridworld",
-      "frameworks": "pymdp",
+      "frameworks": "pymdp,rxinfer,activeinference_jl",
       "representative_files": ["pomdp_gridworld_3x3.md"]
     },
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "generalized-notation-notation"
-version = "1.9.0"
+version = "2.0.0"
 description = "A text-based language for standardizing Active Inference generative models"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/scripts/check_capability_contracts.py
+++ b/scripts/check_capability_contracts.py
@@ -114,6 +114,11 @@ def run_audit() -> List[str]:
         and "**Next Target**: v2.0.0" not in todo_text
     ):
         failures.append("TO-DO.md: v1.9.0 release must set v2.0.0 as next target")
+    if (
+        "**Current Version**: 2.0.0" in todo_text
+        and "**Next Target**: v3.0.0" not in todo_text
+    ):
+        failures.append("TO-DO.md: v2.0.0 release must set v3.0.0 as next target")
 
     readme_tests = _read("src/tests/README.md")
     maintained_dirs, direct_test_dirs = _maintained_test_directory_counts()
@@ -190,6 +195,19 @@ def run_audit() -> List[str]:
             "collect-only inventory",
             "full suite evidence",
         ),
+        "Semantic Round-Trip Gates": (
+            "semantic fidelity gate passed for 9 families",
+            "gnn_semantic_fidelity_ledger_v1",
+            "variables, edges, dimensions, parameter shapes, equations, time, and ontology mappings",
+            "scripts/run_semantic_fidelity_gate.py",
+        ),
+        "Cross-Framework Result Comparisons": (
+            "cross-framework reliability gate passed for 9 families",
+            "gnn_cross_framework_reliability_ledger_v1",
+            "GridWorld compared PyMDP, RxInfer, and ActiveInference.jl",
+            "explicit unsupported statuses",
+            "scripts/run_cross_framework_reliability.py",
+        ),
     }
     for item in guarded_pending_items:
         if f"- [x] **{item}**" in todo_text:
@@ -244,6 +262,26 @@ def run_audit() -> List[str]:
     ):
         if not _exists(required):
             failures.append(f"v1.9 model-family contract missing: {required}")
+
+    for required in (
+        "scripts/run_semantic_fidelity_gate.py",
+        "scripts/run_cross_framework_reliability.py",
+        "src/pipeline/semantic_fidelity.py",
+        "src/pipeline/cross_framework_reliability.py",
+        "src/report/semantic_fidelity.py",
+        "src/report/cross_framework_reliability.py",
+        "src/tests/pipeline/test_semantic_fidelity_gate.py",
+        "src/tests/pipeline/test_cross_framework_reliability.py",
+    ):
+        if not _exists(required):
+            failures.append(f"v2.0 reliability contract missing: {required}")
+
+    if "pymdp,rxinfer,activeinference_jl" not in _read(
+        "input/model_family_manifest.json"
+    ):
+        failures.append(
+            "input/model_family_manifest.json: GridWorld must profile a real multi-backend comparison"
+        )
 
     if "WebSocket" in todo_text:
         if not _contains(

--- a/scripts/run_cross_framework_reliability.py
+++ b/scripts/run_cross_framework_reliability.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Run profiled cross-framework reliability checks for maintained families."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from pipeline.cross_framework_reliability import (
+    MAINTAINED_FRAMEWORKS,
+    run_cross_framework_reliability,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("input/model_family_manifest.json"),
+        help="Path to the model-family manifest",
+    )
+    parser.add_argument(
+        "--families",
+        default="",
+        help="Comma-separated family names to run; defaults to all families",
+    )
+    parser.add_argument(
+        "--frameworks",
+        default=",".join(MAINTAINED_FRAMEWORKS),
+        help="Comma-separated maintained frameworks to profile",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for reliability artifacts",
+    )
+    parser.add_argument("--strict", action="store_true", help="Fail on mismatch")
+    args = parser.parse_args(argv)
+
+    families = [item.strip() for item in args.families.split(",") if item.strip()]
+    frameworks = [item.strip() for item in args.frameworks.split(",") if item.strip()]
+    try:
+        ledger = run_cross_framework_reliability(
+            args.manifest,
+            args.output_dir,
+            family_names=families,
+            frameworks=frameworks,
+            strict=args.strict,
+        )
+    except (FileNotFoundError, KeyError, RuntimeError, ValueError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(f"Cross-framework reliability {ledger['status']}: {args.output_dir}")
+    return 0 if ledger["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_semantic_fidelity_gate.py
+++ b/scripts/run_semantic_fidelity_gate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run strict semantic fidelity checks for maintained model families."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from pipeline.semantic_fidelity import run_semantic_fidelity_gate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("input/model_family_manifest.json"),
+        help="Path to the model-family manifest",
+    )
+    parser.add_argument(
+        "--families",
+        default="",
+        help="Comma-separated family names to run; defaults to all families",
+    )
+    parser.add_argument(
+        "--formats",
+        default="json",
+        help="Comma-separated serializer/parser formats to check",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for semantic fidelity artifacts",
+    )
+    parser.add_argument("--strict", action="store_true", help="Fail on mismatch")
+    args = parser.parse_args(argv)
+
+    families = [item.strip() for item in args.families.split(",") if item.strip()]
+    formats = [item.strip() for item in args.formats.split(",") if item.strip()]
+    try:
+        ledger = run_semantic_fidelity_gate(
+            args.manifest,
+            args.output_dir,
+            family_names=families,
+            formats=formats,
+            strict=args.strict,
+        )
+    except (FileNotFoundError, KeyError, RuntimeError, ValueError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(f"Semantic fidelity {ledger['status']}: {args.output_dir}")
+    return 0 if ledger["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -190,9 +190,9 @@ graph TD
   --ignore=src/tests/llm/test_llm_ollama_integration.py`. Re-include the two Ollama files
   when `ollama` is installed and reachable.
 - **Current test inventory (2026-06-12)**: 184 `test_*.py` files under `src/tests/`;
-  the command-of-record collect pass with Ollama integration tests ignored collected 2,399 tests.
+  the command-of-record collect pass with Ollama integration tests ignored collected 2,411 tests.
   Latest recorded full suite evidence with the same Ollama integration excludes is
-  2,381 passed, 17 skipped, 1 xfailed.
+  2,393 passed, 17 skipped, 1 xfailed.
 - All 25 orchestrator scripts comply with the <150 line thin orchestrator pattern.
 - Maintained source/test documentation coverage is enforced by `doc/development/docs_audit.py --strict`.
 
@@ -342,6 +342,6 @@ pytest --cov=src --cov-report=term-missing
 ---
 
 **Last Updated**: 2026-06-12
-**Pipeline Version**: 1.9.0
+**Pipeline Version**: 2.0.0
 **Total Steps**: 25 (0-24)
 **Status**: Maintained

--- a/src/gnn/parsers/json_serializer.py
+++ b/src/gnn/parsers/json_serializer.py
@@ -63,7 +63,12 @@ class JSONSerializer(BaseGNNSerializer):
                 for param in model.parameters
             ],
             "equations": [
-                str(eq)
+                {
+                    "label": getattr(eq, "label", None),
+                    "content": getattr(eq, "content", ""),
+                    "format": getattr(eq, "format", "latex"),
+                    "description": getattr(eq, "description", ""),
+                }
                 for eq in (model.equations if hasattr(model, "equations") else [])
             ],
             "time_specification": self._serialize_time_spec(model.time_specification)

--- a/src/pipeline/cross_framework_reliability.py
+++ b/src/pipeline/cross_framework_reliability.py
@@ -1,0 +1,503 @@
+"""Cross-framework reliability gates for maintained GNN model families."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from pipeline.model_family_acceptance import (
+    ModelFamily,
+    load_model_family_manifest,
+    run_model_family_acceptance,
+)
+from report.cross_framework_reliability import (
+    render_cross_framework_reliability_markdown,
+)
+
+MAINTAINED_FRAMEWORKS = (
+    "pymdp",
+    "rxinfer",
+    "jax",
+    "numpyro",
+    "pytorch",
+    "activeinference_jl",
+    "discopy",
+)
+FRAMEWORK_RESULT_KEYS = {
+    "pymdp": "pymdp_executions",
+    "rxinfer": "rxinfer_executions",
+    "jax": "jax_executions",
+    "numpyro": "numpyro_executions",
+    "pytorch": "pytorch_executions",
+    "activeinference_jl": "activeinference_executions",
+    "discopy": "discopy_executions",
+}
+SCHEMA_VERSION = "gnn_cross_framework_reliability_ledger_v1"
+AcceptanceRunner = Callable[[ModelFamily, Path], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class FrameworkComparisonIssue:
+    """One cross-framework comparison mismatch."""
+
+    field: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a serializable issue record."""
+        return {"field": self.field, "message": self.message}
+
+
+def run_cross_framework_reliability(
+    manifest_path: Path,
+    output_dir: Path,
+    *,
+    family_names: Iterable[str] | None = None,
+    frameworks: Sequence[str] = MAINTAINED_FRAMEWORKS,
+    strict: bool = False,
+    acceptance_runner: AcceptanceRunner | None = None,
+) -> dict[str, Any]:
+    """Run profiled cross-framework reliability checks."""
+    _validate_frameworks(frameworks)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    families = _select_families(manifest_path, family_names)
+    ledger: dict[str, Any] = {
+        "schema": SCHEMA_VERSION,
+        "created_at": datetime.now().isoformat(),
+        "manifest": str(manifest_path),
+        "strict": strict,
+        "frameworks": list(frameworks),
+        "family_count": len(families),
+        "families": [],
+    }
+
+    failures: list[str] = []
+    runner = acceptance_runner or _default_acceptance_runner(manifest_path)
+    for family in families:
+        family_dir = output_dir / family.name
+        family_dir.mkdir(parents=True, exist_ok=True)
+        acceptance_ledger = runner(family, family_dir / "acceptance")
+        family_result = _first_family_result(acceptance_ledger, family.name)
+        reliability = _build_family_reliability(
+            family,
+            family_result,
+            frameworks,
+        )
+        ledger["families"].append(reliability)
+        if reliability["status"] == "failed":
+            failures.append(family.name)
+
+    ledger["status"] = "failed" if failures else "passed"
+    ledger["failed_families"] = failures
+    _write_ledger(ledger, output_dir)
+    if strict and failures:
+        raise RuntimeError(f"Cross-framework reliability failed: {', '.join(failures)}")
+    return ledger
+
+
+def compare_framework_metrics(
+    framework_metrics: dict[str, dict[str, Any]],
+) -> list[FrameworkComparisonIssue]:
+    """Compare normalized metrics from two or more compatible frameworks."""
+    available = {
+        framework: metrics
+        for framework, metrics in sorted(framework_metrics.items())
+        if metrics.get("available")
+    }
+    if len(available) < 2:
+        return []
+    issues: list[FrameworkComparisonIssue] = []
+    missing_seed = [
+        framework
+        for framework, metrics in available.items()
+        if metrics.get("random_seed") is None
+    ]
+    if missing_seed:
+        issues.append(
+            FrameworkComparisonIssue(
+                field="random_seed",
+                message=(
+                    "Comparable stochastic framework outputs are missing "
+                    f"random_seed: {', '.join(missing_seed)}"
+                ),
+            )
+        )
+
+    reference_name, reference_metrics = next(iter(available.items()))
+    for framework, metrics in list(available.items())[1:]:
+        for field in ("num_timesteps", "matrix_shapes", "trace_lengths"):
+            if metrics.get(field) != reference_metrics.get(field):
+                issues.append(
+                    FrameworkComparisonIssue(
+                        field=field,
+                        message=(
+                            f"{framework} differs from {reference_name}: "
+                            f"{metrics.get(field)!r} != {reference_metrics.get(field)!r}"
+                        ),
+                    )
+                )
+    return issues
+
+
+def collect_framework_metrics(pipeline_output: Path, framework: str) -> dict[str, Any]:
+    """Collect normalized comparable metrics for one framework output."""
+    execution_details = _framework_execution_details(pipeline_output, framework)
+    if not execution_details:
+        return {
+            "available": False,
+            "framework": framework,
+            "reason": "execution_detail_missing_or_invalid",
+        }
+    payload_path = _find_framework_simulation_payload(pipeline_output, framework)
+    if payload_path is None:
+        return {
+            "available": False,
+            "framework": framework,
+            "reason": "simulation_payload_missing",
+        }
+    try:
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "available": False,
+            "framework": framework,
+            "reason": f"simulation_payload_unreadable: {exc}",
+            "source": str(payload_path),
+        }
+    model_parameters = payload.get("model_parameters", {}) or {}
+    runtime_metadata = payload.get("runtime_metadata", {}) or {}
+    return {
+        "available": True,
+        "framework": framework,
+        "source": str(payload_path),
+        "execution_details": [
+            {
+                "script_name": detail.get("script_name"),
+                "model_name": detail.get("model_name"),
+                "return_code": detail.get("return_code"),
+                "structured_result_file": detail.get("structured_result_file"),
+                "implementation_directory": detail.get("implementation_directory"),
+            }
+            for detail in execution_details
+        ],
+        "schema_version": payload.get("schema_version"),
+        "success": payload.get("success"),
+        "random_seed": _first_present(
+            payload,
+            model_parameters,
+            runtime_metadata,
+            ("random_seed", "seed"),
+        ),
+        "num_timesteps": _first_present(
+            payload,
+            model_parameters,
+            runtime_metadata,
+            ("num_timesteps", "timesteps", "T"),
+        ),
+        "matrix_shapes": _matrix_shapes(payload, model_parameters),
+        "trace_lengths": _trace_lengths(payload),
+    }
+
+
+def _default_acceptance_runner(manifest_path: Path) -> AcceptanceRunner:
+    def _run(family: ModelFamily, output_dir: Path) -> dict[str, Any]:
+        return run_model_family_acceptance(
+            manifest_path,
+            output_dir,
+            family_names=[family.name],
+            frameworks=family.frameworks,
+            strict=True,
+        )
+
+    return _run
+
+
+def _select_families(
+    manifest_path: Path, family_names: Iterable[str] | None
+) -> list[ModelFamily]:
+    requested = {name.strip() for name in family_names or [] if name.strip()}
+    families = load_model_family_manifest(manifest_path)
+    selected = [
+        family for family in families if not requested or family.name in requested
+    ]
+    missing = sorted(requested - {family.name for family in families})
+    if missing:
+        raise KeyError(f"Unknown model families: {', '.join(missing)}")
+    return selected
+
+
+def _build_family_reliability(
+    family: ModelFamily,
+    family_result: dict[str, Any],
+    frameworks: Sequence[str],
+) -> dict[str, Any]:
+    profile = _compatibility_profile(family, frameworks)
+    framework_results: dict[str, dict[str, Any]] = {}
+    pipeline_output = _pipeline_output_from_family_result(family_result)
+    for framework in frameworks:
+        framework_results[framework] = _framework_reliability_result(
+            framework,
+            profile[framework],
+            family_result,
+            pipeline_output,
+        )
+
+    comparable_metrics = {
+        framework: result.get("metrics", {})
+        for framework, result in framework_results.items()
+        if result["status"] == "passed" and result.get("metrics", {}).get("available")
+    }
+    comparison_issues = compare_framework_metrics(comparable_metrics)
+    comparison_status = (
+        "failed"
+        if comparison_issues
+        else "passed"
+        if len(comparable_metrics) >= 2
+        else "skipped"
+    )
+    required_failures = [
+        framework
+        for framework, result in framework_results.items()
+        if result["profile"] == "required" and result["status"] != "passed"
+    ]
+    status = "failed" if required_failures or comparison_issues else "passed"
+    return {
+        "name": family.name,
+        "description": family.description,
+        "status": status,
+        "acceptance_status": family_result.get("status"),
+        "frameworks": framework_results,
+        "comparison": {
+            "status": comparison_status,
+            "reason": (
+                "fewer_than_two_compatible_outputs"
+                if len(comparable_metrics) < 2 and not comparison_issues
+                else None
+            ),
+            "compared_frameworks": sorted(comparable_metrics),
+            "issues": [issue.to_dict() for issue in comparison_issues],
+        },
+        "required_framework_failures": required_failures,
+        "artifact_links": family_result.get("artifact_links", []),
+    }
+
+
+def _compatibility_profile(
+    family: ModelFamily, frameworks: Sequence[str]
+) -> dict[str, dict[str, str]]:
+    required = set(_parse_framework_list(family.frameworks))
+    profile: dict[str, dict[str, str]] = {}
+    family_unsupported_steps = set(
+        (family.acceptance_profile or {}).get("allow_unsupported_steps", [])
+    )
+    render_execute_unsupported = {11, 12}.issubset(family_unsupported_steps)
+    for framework in frameworks:
+        if framework in required and not render_execute_unsupported:
+            profile[framework] = {
+                "status": "required",
+                "reason": "family manifest compatible backend",
+            }
+        else:
+            reason = (
+                "family profile declares Step 11/12 unsupported"
+                if render_execute_unsupported and framework in required
+                else "not declared compatible for this model family"
+            )
+            profile[framework] = {"status": "unsupported", "reason": reason}
+    return profile
+
+
+def _framework_reliability_result(
+    framework: str,
+    profile: dict[str, str],
+    family_result: dict[str, Any],
+    pipeline_output: Path | None,
+) -> dict[str, Any]:
+    if profile["status"] == "unsupported":
+        return {
+            "profile": "unsupported",
+            "status": "unsupported",
+            "reason": profile["reason"],
+            "metrics": {"available": False, "reason": profile["reason"]},
+        }
+
+    step_evidence = family_result.get("step_evidence", {})
+    step_11 = step_evidence.get("11", {})
+    step_12 = step_evidence.get("12", {})
+    if family_result.get("status") != "passed":
+        return {
+            "profile": "required",
+            "status": "failed",
+            "reason": "family_acceptance_failed",
+            "metrics": {"available": False},
+        }
+    for step, evidence in (("11", step_11), ("12", step_12)):
+        if evidence.get("status") != "passed":
+            return {
+                "profile": "required",
+                "status": "failed",
+                "reason": f"step_{step}_evidence_not_passed",
+                "metrics": {"available": False},
+            }
+    if pipeline_output is None:
+        return {
+            "profile": "required",
+            "status": "failed",
+            "reason": "pipeline_output_unknown",
+            "metrics": {"available": False},
+        }
+    metrics = collect_framework_metrics(pipeline_output, framework)
+    return {
+        "profile": "required",
+        "status": "passed" if metrics.get("available") else "failed",
+        "reason": None if metrics.get("available") else metrics.get("reason"),
+        "metrics": metrics,
+    }
+
+
+def _pipeline_output_from_family_result(family_result: dict[str, Any]) -> Path | None:
+    command = family_result.get("command", [])
+    if isinstance(command, list) and "--output-dir" in command:
+        index = command.index("--output-dir") + 1
+        if index < len(command):
+            return Path(str(command[index]))
+    staged = family_result.get("staged_target_dir")
+    if staged:
+        staged_path = Path(str(staged))
+        candidate = staged_path.parent / "pipeline_output"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _first_family_result(ledger: dict[str, Any], family_name: str) -> dict[str, Any]:
+    for family in ledger.get("families", []):
+        if family.get("name") == family_name:
+            return family
+    raise ValueError(f"Acceptance ledger did not include {family_name}")
+
+
+def _find_framework_simulation_payload(
+    pipeline_output: Path, framework: str
+) -> Path | None:
+    execute_dir = pipeline_output / "12_execute_output"
+    candidates = [
+        path
+        for path in execute_dir.rglob("*simulation_results.json")
+        if framework in path.parts
+    ]
+    if not candidates:
+        candidates = [
+            path
+            for path in execute_dir.rglob("simulation_results.json")
+            if framework in path.parts
+        ]
+    return sorted(candidates)[0] if candidates else None
+
+
+def _framework_execution_details(
+    pipeline_output: Path, framework: str
+) -> list[dict[str, Any]]:
+    summary_path = (
+        pipeline_output / "12_execute_output" / "summaries" / "execution_summary.json"
+    )
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    details = [
+        detail
+        for detail in summary.get("execution_details", [])
+        if isinstance(detail, dict) and detail.get("framework") == framework
+    ]
+    if not details:
+        return []
+    valid_details: list[dict[str, Any]] = []
+    for detail in details:
+        structured_result = detail.get("structured_result_file")
+        if (
+            detail.get("success") is not True
+            or detail.get("skipped") is True
+            or detail.get("return_code") != 0
+            or not structured_result
+            or not Path(str(structured_result)).exists()
+        ):
+            return []
+        valid_details.append(detail)
+    return valid_details
+
+
+def _matrix_shapes(
+    payload: dict[str, Any], model_parameters: dict[str, Any]
+) -> dict[str, Any]:
+    shapes: dict[str, Any] = {}
+    provenance = payload.get("matrix_provenance")
+    if isinstance(provenance, dict):
+        for matrix_name, matrix_info in provenance.items():
+            if isinstance(matrix_info, dict) and "shape" in matrix_info:
+                shapes[f"{matrix_name}_shape"] = matrix_info["shape"]
+        shapes["matrix_provenance_keys"] = sorted(provenance)
+        return dict(sorted(shapes.items()))
+    for key, value in model_parameters.items():
+        if key.endswith("_shape"):
+            shapes[key] = value
+    return dict(sorted(shapes.items()))
+
+
+def _trace_lengths(payload: dict[str, Any]) -> dict[str, int]:
+    keys = (
+        "observations",
+        "actions",
+        "beliefs",
+        "expected_free_energy",
+        "free_energy",
+        "policy_posterior",
+    )
+    lengths: dict[str, int] = {}
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, list):
+            lengths[key] = len(value)
+    return dict(sorted(lengths.items()))
+
+
+def _first_present(
+    payload: dict[str, Any],
+    model_parameters: dict[str, Any],
+    runtime_metadata: dict[str, Any],
+    keys: tuple[str, ...],
+) -> Any:
+    for key in keys:
+        if key in payload:
+            return payload[key]
+        if key in model_parameters:
+            return model_parameters[key]
+        if key in runtime_metadata:
+            return runtime_metadata[key]
+    return None
+
+
+def _parse_framework_list(frameworks: str | None) -> list[str]:
+    if not frameworks:
+        return []
+    return [item.strip() for item in frameworks.split(",") if item.strip()]
+
+
+def _validate_frameworks(frameworks: Sequence[str]) -> None:
+    unknown = sorted(set(frameworks) - set(MAINTAINED_FRAMEWORKS))
+    if unknown:
+        raise ValueError(f"Unprofiled frameworks: {', '.join(unknown)}")
+
+
+def _write_ledger(ledger: dict[str, Any], output_dir: Path) -> None:
+    (output_dir / "cross_framework_reliability_ledger.json").write_text(
+        json.dumps(ledger, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    (output_dir / "cross_framework_reliability_ledger.md").write_text(
+        render_cross_framework_reliability_markdown(ledger),
+        encoding="utf-8",
+    )

--- a/src/pipeline/cross_framework_reliability.py
+++ b/src/pipeline/cross_framework_reliability.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Sequence, cast
 
 from pipeline.model_family_acceptance import (
     ModelFamily,
@@ -376,7 +376,7 @@ def _pipeline_output_from_family_result(family_result: dict[str, Any]) -> Path |
 def _first_family_result(ledger: dict[str, Any], family_name: str) -> dict[str, Any]:
     for family in ledger.get("families", []):
         if family.get("name") == family_name:
-            return family
+            return cast("dict[str, Any]", family)
     raise ValueError(f"Acceptance ledger did not include {family_name}")
 
 

--- a/src/pipeline/semantic_fidelity.py
+++ b/src/pipeline/semantic_fidelity.py
@@ -1,0 +1,470 @@
+"""Semantic fidelity gates for maintained GNN model families."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from gnn.parsers import GNNFormat, GNNParsingSystem
+from gnn.schema import (
+    parse_connections,
+    parse_state_space,
+    validate_matrix_dimensions,
+)
+from pipeline.model_family_acceptance import (
+    ModelFamily,
+    load_model_family_manifest,
+)
+from report.semantic_fidelity import render_semantic_fidelity_markdown
+
+STRICT_ROUND_TRIP_FORMATS = ("json",)
+SCHEMA_VERSION = "gnn_semantic_fidelity_ledger_v1"
+CONTRACT_SCHEMA_VERSION = "gnn_semantic_contract_v1"
+
+
+@dataclass(frozen=True)
+class SemanticDifference:
+    """One strict semantic contract mismatch."""
+
+    field: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a serializable difference record."""
+        return {"field": self.field, "message": self.message}
+
+
+def run_semantic_fidelity_gate(
+    manifest_path: Path,
+    output_dir: Path,
+    *,
+    family_names: Iterable[str] | None = None,
+    formats: Sequence[str] = STRICT_ROUND_TRIP_FORMATS,
+    strict: bool = False,
+) -> dict[str, Any]:
+    """Run strict parse -> serialize -> parse fidelity checks."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    families = _select_families(manifest_path, family_names)
+    ledger: dict[str, Any] = {
+        "schema": SCHEMA_VERSION,
+        "created_at": datetime.now().isoformat(),
+        "manifest": str(manifest_path),
+        "strict": strict,
+        "formats": list(formats),
+        "family_count": len(families),
+        "families": [],
+    }
+
+    failures: list[str] = []
+    for family in families:
+        family_result = _run_family_fidelity(family, formats, output_dir)
+        ledger["families"].append(family_result)
+        if family_result["status"] == "failed":
+            failures.append(family.name)
+
+    ledger["status"] = "failed" if failures else "passed"
+    ledger["failed_families"] = failures
+    _write_ledger(ledger, output_dir)
+    if strict and failures:
+        raise RuntimeError(f"Semantic fidelity failed: {', '.join(failures)}")
+    return ledger
+
+
+def build_semantic_contract(model_path: Path) -> dict[str, Any]:
+    """Build the stable v2 semantic contract for one model source."""
+    system = GNNParsingSystem(strict_validation=False)
+    parse_result = system.parse_file(model_path)
+    if not parse_result.success or parse_result.model is None:
+        errors = getattr(parse_result, "errors", []) or ["parse failed"]
+        raise ValueError(f"Could not parse {model_path}: {'; '.join(errors)}")
+
+    model = parse_result.model
+    content = model_path.read_text(encoding="utf-8")
+    schema_variables, variable_errors = parse_state_space(
+        content, file_path=str(model_path)
+    )
+    known_variables = {variable.name for variable in schema_variables}
+    _, connection_errors = parse_connections(
+        content, known_variables=known_variables, file_path=str(model_path)
+    )
+    matrix_errors = validate_matrix_dimensions(
+        content, schema_variables, file_path=str(model_path)
+    )
+
+    contract = {
+        "schema": CONTRACT_SCHEMA_VERSION,
+        "source_file": str(model_path),
+        "model_identity": {
+            "model_name": str(model.model_name),
+            "version": str(model.version),
+            "annotation": str(model.annotation),
+        },
+        "variables": _canonical_variables(model),
+        "edges": _canonical_edges(model),
+        "parameter_shapes": _canonical_parameter_shapes(model),
+        "parameter_names": sorted(
+            str(parameter.name) for parameter in model.parameters if parameter.name
+        ),
+        "equations": _canonical_equations(model),
+        "time_specification": _canonical_time_specification(model),
+        "ontology_mappings": _canonical_ontology_mappings(model),
+        "declared_metadata": {
+            "raw_sections": sorted(str(name) for name in model.raw_sections),
+            "source_format": (
+                model.source_format.value if model.source_format else "markdown"
+            ),
+            "extensions": sorted(str(name) for name in model.extensions),
+        },
+        "parser_diagnostics": {
+            "variable_errors": [str(error) for error in variable_errors],
+            "connection_errors": [str(error) for error in connection_errors],
+            "matrix_errors": [str(error) for error in matrix_errors],
+            "structure_issues": model.validate_structure(),
+        },
+    }
+    contract["contract_hash"] = _contract_hash(contract)
+    return contract
+
+
+def compare_semantic_contracts(
+    original: dict[str, Any], reparsed: dict[str, Any]
+) -> list[SemanticDifference]:
+    """Return strict differences between two semantic contracts."""
+    differences: list[SemanticDifference] = []
+    for field in (
+        "model_identity",
+        "variables",
+        "edges",
+        "parameter_shapes",
+        "parameter_names",
+        "equations",
+        "time_specification",
+        "ontology_mappings",
+    ):
+        if original.get(field) != reparsed.get(field):
+            differences.append(
+                SemanticDifference(
+                    field=field,
+                    message=f"{field} changed across semantic round trip",
+                )
+            )
+    return differences
+
+
+def _select_families(
+    manifest_path: Path, family_names: Iterable[str] | None
+) -> list[ModelFamily]:
+    requested = {name.strip() for name in family_names or [] if name.strip()}
+    families = load_model_family_manifest(manifest_path)
+    selected = [
+        family for family in families if not requested or family.name in requested
+    ]
+    missing = sorted(requested - {family.name for family in families})
+    if missing:
+        raise KeyError(f"Unknown model families: {', '.join(missing)}")
+    return selected
+
+
+def _run_family_fidelity(
+    family: ModelFamily, formats: Sequence[str], output_dir: Path
+) -> dict[str, Any]:
+    model_results: list[dict[str, Any]] = []
+    family_dir = output_dir / family.name
+    family_dir.mkdir(parents=True, exist_ok=True)
+    for relative_name in family.representative_files:
+        source = family.target_dir / relative_name
+        if not source.exists():
+            raise FileNotFoundError(f"Representative fixture not found: {source}")
+        model_results.append(_run_model_fidelity(source, family_dir, formats))
+
+    failed_models = [
+        result["source_file"]
+        for result in model_results
+        if result["status"] == "failed"
+    ]
+    return {
+        "name": family.name,
+        "description": family.description,
+        "status": "failed" if failed_models else "passed",
+        "model_count": len(model_results),
+        "failed_models": failed_models,
+        "models": model_results,
+    }
+
+
+def _run_model_fidelity(
+    model_path: Path, family_dir: Path, formats: Sequence[str]
+) -> dict[str, Any]:
+    original_contract = build_semantic_contract(model_path)
+    contract_path = family_dir / f"{model_path.stem}_semantic_contract.json"
+    contract_path.write_text(
+        json.dumps(original_contract, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    round_trips = [
+        _run_format_round_trip(model_path, original_contract, family_dir, fmt)
+        for fmt in formats
+    ]
+    failed_formats = [
+        result["format"] for result in round_trips if result["status"] == "failed"
+    ]
+    return {
+        "source_file": str(model_path),
+        "contract_hash": original_contract["contract_hash"],
+        "contract_artifact": str(contract_path),
+        "status": "failed" if failed_formats else "passed",
+        "round_trips": round_trips,
+    }
+
+
+def _run_format_round_trip(
+    model_path: Path,
+    original_contract: dict[str, Any],
+    family_dir: Path,
+    format_name: str,
+) -> dict[str, Any]:
+    system = GNNParsingSystem(strict_validation=False)
+    source_result = system.parse_file(model_path)
+    if source_result.model is None:
+        return {
+            "format": format_name,
+            "status": "failed",
+            "reason": "source_parse_failed",
+            "differences": [],
+        }
+    try:
+        gnn_format = GNNFormat(format_name)
+    except ValueError:
+        return {
+            "format": format_name,
+            "status": "failed",
+            "reason": "unsupported_format",
+            "differences": [],
+        }
+    if gnn_format not in system.serializers or gnn_format not in system.parsers:
+        return {
+            "format": format_name,
+            "status": "failed",
+            "reason": "unsupported_serializer_or_parser",
+            "differences": [],
+        }
+
+    try:
+        serialized = system.serialize(source_result.model, gnn_format)
+        artifact = family_dir / f"{model_path.stem}.{format_name}"
+        artifact.write_text(serialized, encoding="utf-8")
+        reparsed = system.parse_string(serialized, gnn_format)
+        if not reparsed.success or reparsed.model is None:
+            return {
+                "format": format_name,
+                "status": "failed",
+                "reason": "reparse_failed",
+                "artifact": str(artifact),
+                "differences": [],
+            }
+        reparsed_contract = _contract_from_model(
+            deepcopy(original_contract), reparsed.model
+        )
+        differences = compare_semantic_contracts(original_contract, reparsed_contract)
+    except Exception as exc:  # pragma: no cover - defensive ledger detail
+        return {
+            "format": format_name,
+            "status": "failed",
+            "reason": f"round_trip_error: {exc}",
+            "differences": [],
+        }
+
+    return {
+        "format": format_name,
+        "status": "failed" if differences else "passed",
+        "reason": None if not differences else "semantic_contract_changed",
+        "artifact": str(artifact),
+        "differences": [difference.to_dict() for difference in differences],
+    }
+
+
+def _contract_from_model(source_contract: dict[str, Any], model: Any) -> dict[str, Any]:
+    """Build a contract from an already parsed model using source diagnostics."""
+    contract = deepcopy(source_contract)
+    contract["source_file"] = "<serialized-round-trip>"
+    contract["model_identity"] = {
+        "model_name": str(model.model_name),
+        "version": str(model.version),
+        "annotation": str(model.annotation),
+    }
+    contract["variables"] = _canonical_variables(model)
+    contract["edges"] = _canonical_edges(model)
+    contract["parameter_shapes"] = _canonical_parameter_shapes(model)
+    contract["parameter_names"] = sorted(
+        str(parameter.name) for parameter in model.parameters if parameter.name
+    )
+    contract["equations"] = _canonical_equations(model)
+    contract["time_specification"] = _canonical_time_specification(model)
+    contract["ontology_mappings"] = _canonical_ontology_mappings(model)
+    contract["declared_metadata"] = {
+        "raw_sections": sorted(str(name) for name in model.raw_sections),
+        "source_format": model.source_format.value if model.source_format else "json",
+        "extensions": sorted(str(name) for name in model.extensions),
+    }
+    contract["contract_hash"] = _contract_hash(contract)
+    return contract
+
+
+def _canonical_variables(model: Any) -> list[dict[str, Any]]:
+    variables = []
+    for variable in model.variables:
+        variables.append(
+            {
+                "name": str(variable.name),
+                "dimensions": [
+                    _normalize_dimension(dim) for dim in variable.dimensions
+                ],
+                "var_type": str(getattr(variable.var_type, "value", variable.var_type)),
+                "data_type": str(
+                    getattr(variable.data_type, "value", variable.data_type)
+                ),
+                "description": str(variable.description or ""),
+                "constraints": _json_stable(variable.constraints),
+            }
+        )
+    return sorted(variables, key=lambda item: item["name"])
+
+
+def _canonical_edges(model: Any) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    for connection in model.connections:
+        connection_type = str(
+            getattr(connection.connection_type, "value", connection.connection_type)
+        )
+        for source in connection.source_variables:
+            for target in connection.target_variables:
+                edges.append(
+                    {
+                        "source": str(source),
+                        "target": str(target),
+                        "connection_type": connection_type,
+                        "weight": connection.weight,
+                        "description": str(connection.description or ""),
+                    }
+                )
+    return sorted(
+        edges,
+        key=lambda item: (
+            item["source"],
+            item["target"],
+            item["connection_type"],
+        ),
+    )
+
+
+def _canonical_parameter_shapes(model: Any) -> dict[str, list[int]]:
+    shapes: dict[str, list[int]] = {}
+    for parameter in model.parameters:
+        name = str(parameter.name).strip()
+        if not name:
+            continue
+        shapes[name] = _shape_of(parameter.value)
+    return dict(sorted(shapes.items()))
+
+
+def _canonical_equations(model: Any) -> list[dict[str, str]]:
+    equations = []
+    for equation in getattr(model, "equations", []):
+        equations.append(
+            {
+                "label": str(equation.label or ""),
+                "content": str(equation.content),
+                "format": str(equation.format),
+                "description": str(equation.description or ""),
+            }
+        )
+    return sorted(
+        equations,
+        key=lambda item: (
+            item["label"],
+            item["content"],
+            item["format"],
+            item["description"],
+        ),
+    )
+
+
+def _canonical_time_specification(model: Any) -> dict[str, Any] | None:
+    time_spec = getattr(model, "time_specification", None)
+    if time_spec is None:
+        return None
+    return {
+        "time_type": str(time_spec.time_type),
+        "discretization": str(time_spec.discretization or ""),
+        "horizon": time_spec.horizon,
+        "step_size": time_spec.step_size,
+    }
+
+
+def _canonical_ontology_mappings(model: Any) -> list[dict[str, str]]:
+    mappings = []
+    for mapping in getattr(model, "ontology_mappings", []):
+        mappings.append(
+            {
+                "variable_name": str(mapping.variable_name),
+                "ontology_term": str(mapping.ontology_term),
+                "description": str(mapping.description or ""),
+            }
+        )
+    return sorted(
+        mappings,
+        key=lambda item: (
+            item["variable_name"],
+            item["ontology_term"],
+            item["description"],
+        ),
+    )
+
+
+def _shape_of(value: Any) -> list[int]:
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return [0]
+        child_shape = _shape_of(value[0])
+        return [len(value), *child_shape]
+    return []
+
+
+def _normalize_dimension(value: Any) -> int | str:
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    try:
+        return int(text)
+    except ValueError:
+        return text
+
+
+def _json_stable(value: Any) -> Any:
+    return json.loads(json.dumps(value, sort_keys=True, default=str))
+
+
+def _contract_hash(contract: dict[str, Any]) -> str:
+    stable = {
+        key: value
+        for key, value in contract.items()
+        if key not in {"contract_hash", "source_file", "parser_diagnostics"}
+    }
+    payload = json.dumps(stable, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _write_ledger(ledger: dict[str, Any], output_dir: Path) -> None:
+    (output_dir / "semantic_fidelity_ledger.json").write_text(
+        json.dumps(ledger, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    (output_dir / "semantic_fidelity_ledger.md").write_text(
+        render_semantic_fidelity_markdown(ledger),
+        encoding="utf-8",
+    )

--- a/src/report/cross_framework_reliability.py
+++ b/src/report/cross_framework_reliability.py
@@ -1,0 +1,52 @@
+"""Markdown rendering for cross-framework reliability ledgers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_cross_framework_reliability_markdown(ledger: dict[str, Any]) -> str:
+    """Render a compact Markdown report for v2 cross-framework reliability."""
+    lines = [
+        "# GNN Cross-Framework Reliability Ledger",
+        "",
+        f"- Schema: {ledger['schema']}",
+        f"- Families: {ledger['family_count']}",
+        f"- Strict: {str(ledger['strict']).lower()}",
+        f"- Frameworks: {', '.join(ledger.get('frameworks', []))}",
+        "",
+        "| Family | Status | Comparison | Compared Frameworks | Required Failures |",
+        "| --- | --- | --- | --- | ---: |",
+    ]
+    for family in ledger["families"]:
+        comparison = family["comparison"]
+        lines.append(
+            "| {name} | {status} | {comparison} | {frameworks} | {failures} |".format(
+                name=family["name"],
+                status=family["status"],
+                comparison=comparison["status"],
+                frameworks=", ".join(comparison.get("compared_frameworks", []))
+                or "none",
+                failures=len(family.get("required_framework_failures", [])),
+            )
+        )
+    lines.extend(["", "## Framework Profiles", ""])
+    for family in ledger["families"]:
+        lines.append(f"### {family['name']}")
+        lines.append("")
+        lines.append("| Framework | Profile | Status | Reason | Metrics |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for framework, result in family["frameworks"].items():
+            metrics = result.get("metrics", {})
+            metric_status = "available" if metrics.get("available") else "missing"
+            lines.append(
+                "| {framework} | {profile} | {status} | {reason} | {metrics} |".format(
+                    framework=framework,
+                    profile=result["profile"],
+                    status=result["status"],
+                    reason=result.get("reason") or "",
+                    metrics=metric_status,
+                )
+            )
+        lines.append("")
+    return "\n".join(lines)

--- a/src/report/semantic_fidelity.py
+++ b/src/report/semantic_fidelity.py
@@ -1,0 +1,48 @@
+"""Markdown rendering for semantic fidelity ledgers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_semantic_fidelity_markdown(ledger: dict[str, Any]) -> str:
+    """Render a compact Markdown report for the semantic fidelity gate."""
+    lines = [
+        "# GNN Semantic Fidelity Ledger",
+        "",
+        f"- Schema: {ledger['schema']}",
+        f"- Families: {ledger['family_count']}",
+        f"- Strict: {str(ledger['strict']).lower()}",
+        f"- Formats: {', '.join(ledger.get('formats', [])) or 'none'}",
+        "",
+        "| Family | Status | Models | Failed Models |",
+        "| --- | --- | ---: | ---: |",
+    ]
+    for family in ledger["families"]:
+        lines.append(
+            "| {name} | {status} | {models} | {failed} |".format(
+                name=family["name"],
+                status=family["status"],
+                models=family["model_count"],
+                failed=len(family.get("failed_models", [])),
+            )
+        )
+    lines.extend(["", "## Round Trips", ""])
+    for family in ledger["families"]:
+        for model in family["models"]:
+            lines.append(f"### {family['name']} / {model['source_file']}")
+            lines.append("")
+            lines.append("| Format | Status | Reason | Differences | Artifact |")
+            lines.append("| --- | --- | --- | ---: | --- |")
+            for round_trip in model["round_trips"]:
+                lines.append(
+                    "| {fmt} | {status} | {reason} | {diffs} | {artifact} |".format(
+                        fmt=round_trip["format"],
+                        status=round_trip["status"],
+                        reason=round_trip.get("reason") or "",
+                        diffs=len(round_trip.get("differences", [])),
+                        artifact=round_trip.get("artifact", ""),
+                    )
+                )
+            lines.append("")
+    return "\n".join(lines)

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -34,10 +34,10 @@ pytest -m slow          # slow/performance tests only
 ## Test Statistics
 
 - **Total test files**: 184 (155 in subdirectories + 29 at root)
-- **Test collection baseline**: 2,399 collected with the command-of-record
+- **Test collection baseline**: 2,411 collected with the command-of-record
   collect pass and the two local Ollama integration files ignored
 - **Pass/skip baseline**: the latest recorded command-of-record full run with the
-  two local Ollama integration files ignored is 2,381 passed, 17 skipped, 1 xfailed
+  two local Ollama integration files ignored is 2,393 passed, 17 skipped, 1 xfailed
 - **Fast-test duration**: 1-3 minutes
 - **Full-suite duration**: varies by optional backend availability; latest
   command-of-record run completed in 12:09
@@ -646,8 +646,8 @@ If issues persist:
 ### Test Coverage
 
 - **184 test files** across root and module-specific directories
-- **2,399 collected tests** in the current command-of-record collect pass with Ollama integration tests ignored
-- **Latest recorded full suite evidence** with the same Ollama integration excludes: 2,381 passed, 17 skipped, 1 xfailed
+- **2,411 collected tests** in the current command-of-record collect pass with Ollama integration tests ignored
+- **Latest recorded full suite evidence** with the same Ollama integration excludes: 2,393 passed, 17 skipped, 1 xfailed
 - **Comprehensive module coverage** for all major modules
 - **Specialized test areas** for specific functionality
 - **Integration tests** for cross-module functionality
@@ -682,7 +682,7 @@ Module coverage mirrors the maintained source tree. Use `rg --files src/tests -g
 
 ## Test Execution Results
 
-Latest measured collect-only inventory (2026-06-12): 184 `test_*.py` files and 2,399 collected tests with the Ollama integration files excluded. Latest recorded full command-of-record evidence with the same excludes: 2,381 passed, 17 skipped, 1 xfailed.
+Latest measured collect-only inventory (2026-06-12): 186 `test_*.py` files and 2,411 collected tests with the Ollama integration files excluded. Latest recorded full command-of-record evidence with the same excludes: 2,393 passed, 17 skipped, 1 xfailed.
 
 ```bash
 uv run --extra dev python -m pytest src/tests/ -q --tb=no \

--- a/src/tests/TEST_SUITE_SUMMARY.md
+++ b/src/tests/TEST_SUITE_SUMMARY.md
@@ -16,8 +16,8 @@ The GNN Processing Pipeline test suite provides comprehensive coverage across al
 - **Directory Layout**: 34 maintained first-level directories under `src/tests/`; 32 contain direct test files
 - **Root-Level Tests**: 29 `test_*.py` files at `src/tests/`
 - **Subdirectory Tests**: 155 `test_*.py` files under module/helper directories
-- **Collected Tests**: 2,399 with `uv run --extra dev python -m pytest --collect-only src/tests/ -q --tb=no --ignore=src/tests/llm/test_llm_ollama.py --ignore=src/tests/llm/test_llm_ollama_integration.py` (2026-06-12)
-- **Latest Full Run Evidence**: `uv run --extra dev python -m pytest src/tests/ -q --tb=no --ignore=src/tests/llm/test_llm_ollama.py --ignore=src/tests/llm/test_llm_ollama_integration.py`: 2,381 passed, 17 skipped, 1 xfailed.
+- **Collected Tests**: 2,411 with `uv run --extra dev python -m pytest --collect-only src/tests/ -q --tb=no --ignore=src/tests/llm/test_llm_ollama.py --ignore=src/tests/llm/test_llm_ollama_integration.py` (2026-06-12)
+- **Latest Full Run Evidence**: `uv run --extra dev python -m pytest src/tests/ -q --tb=no --ignore=src/tests/llm/test_llm_ollama.py --ignore=src/tests/llm/test_llm_ollama_integration.py`: 2,393 passed, 17 skipped, 1 xfailed.
 
 ---
 
@@ -284,8 +284,8 @@ output/2_tests_output/
 The GNN Processing Pipeline test suite provides comprehensive, production-ready testing infrastructure with:
 
 - 184 test files across root and module-specific directories
-- 2,399 collected tests in the current command-of-record collect pass with Ollama integration tests ignored
-- Latest recorded full command-of-record evidence: 2,381 passed, 17 skipped, 1 xfailed
+- 2,411 collected tests in the current command-of-record collect pass with Ollama integration tests ignored
+- Latest recorded full command-of-record evidence: 2,393 passed, 17 skipped, 1 xfailed
 - Real data and real implementations throughout core paths
 - Comprehensive error handling and recovery testing
 - Module coverage for all 25 pipeline steps

--- a/src/tests/pipeline/test_cross_framework_reliability.py
+++ b/src/tests/pipeline/test_cross_framework_reliability.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pipeline.cross_framework_reliability import (
+    compare_framework_metrics,
+    run_cross_framework_reliability,
+)
+
+
+def test_cross_framework_gate_profiles_all_maintained_backends(
+    tmp_path: Path,
+) -> None:
+    def acceptance_runner(_family: object, output_dir: Path) -> dict[str, object]:
+        pipeline_output = output_dir / "basics" / "pipeline_output"
+        _write_simulation_payload(pipeline_output, "pymdp")
+        _write_execution_summary(pipeline_output, "pymdp")
+        return _acceptance_ledger("basics", pipeline_output)
+
+    ledger = run_cross_framework_reliability(
+        Path("input/model_family_manifest.json"),
+        tmp_path,
+        family_names=["basics"],
+        strict=True,
+        acceptance_runner=acceptance_runner,
+    )
+
+    family = ledger["families"][0]
+    assert ledger["status"] == "passed"
+    assert family["frameworks"]["pymdp"]["status"] == "passed"
+    assert family["frameworks"]["rxinfer"]["status"] == "unsupported"
+    assert family["comparison"]["status"] == "skipped"
+    assert (tmp_path / "cross_framework_reliability_ledger.json").exists()
+    assert (tmp_path / "cross_framework_reliability_ledger.md").exists()
+
+
+def test_cross_framework_gate_fails_missing_step_12_evidence(
+    tmp_path: Path,
+) -> None:
+    def acceptance_runner(_family: object, output_dir: Path) -> dict[str, object]:
+        pipeline_output = output_dir / "basics" / "pipeline_output"
+        _write_simulation_payload(pipeline_output, "pymdp")
+        _write_execution_summary(pipeline_output, "pymdp")
+        ledger = _acceptance_ledger("basics", pipeline_output)
+        ledger["families"][0]["step_evidence"]["12"]["status"] = "failed"
+        return ledger
+
+    with pytest.raises(RuntimeError, match="Cross-framework reliability failed"):
+        run_cross_framework_reliability(
+            Path("input/model_family_manifest.json"),
+            tmp_path,
+            family_names=["basics"],
+            strict=True,
+            acceptance_runner=acceptance_runner,
+        )
+
+
+def test_cross_framework_gate_fails_unprofiled_framework(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unprofiled frameworks"):
+        run_cross_framework_reliability(
+            Path("input/model_family_manifest.json"),
+            tmp_path,
+            family_names=["basics"],
+            frameworks=("pymdp", "made_up_backend"),
+            strict=True,
+        )
+
+
+def test_compare_framework_metrics_fails_on_metric_mismatch() -> None:
+    issues = compare_framework_metrics(
+        {
+            "pymdp": {
+                "available": True,
+                "random_seed": 42,
+                "num_timesteps": 10,
+                "matrix_shapes": {"B_shape": [3, 3, 2]},
+                "trace_lengths": {"actions": 10},
+            },
+            "jax": {
+                "available": True,
+                "random_seed": 42,
+                "num_timesteps": 11,
+                "matrix_shapes": {"B_shape": [3, 3, 2]},
+                "trace_lengths": {"actions": 10},
+            },
+        }
+    )
+
+    assert any(issue.field == "num_timesteps" for issue in issues)
+
+
+def test_compare_framework_metrics_fails_missing_seed() -> None:
+    issues = compare_framework_metrics(
+        {
+            "pymdp": {
+                "available": True,
+                "random_seed": 42,
+                "num_timesteps": 10,
+                "matrix_shapes": {},
+                "trace_lengths": {},
+            },
+            "jax": {
+                "available": True,
+                "random_seed": None,
+                "num_timesteps": 10,
+                "matrix_shapes": {},
+                "trace_lengths": {},
+            },
+        }
+    )
+
+    assert any(issue.field == "random_seed" for issue in issues)
+
+
+def _acceptance_ledger(name: str, pipeline_output: Path) -> dict[str, object]:
+    return {
+        "schema": "gnn_model_family_acceptance_ledger_v1",
+        "status": "passed",
+        "families": [
+            {
+                "name": name,
+                "status": "passed",
+                "command": [
+                    "python",
+                    "src/main.py",
+                    "--output-dir",
+                    str(pipeline_output),
+                ],
+                "step_evidence": {
+                    "11": {"status": "passed"},
+                    "12": {"status": "passed"},
+                },
+                "artifact_links": [str(pipeline_output / "12_execute_output")],
+            }
+        ],
+    }
+
+
+def _write_simulation_payload(pipeline_output: Path, framework: str) -> None:
+    payload_dir = (
+        pipeline_output / "12_execute_output" / "demo" / framework / "simulation_data"
+    )
+    payload_dir.mkdir(parents=True, exist_ok=True)
+    (payload_dir / "demo_simulation_results.json").write_text(
+        json.dumps(
+            {
+                "schema_version": f"{framework}_simulation_v1",
+                "success": True,
+                "random_seed": 42,
+                "num_timesteps": 5,
+                "observations": [0, 1, 0, 1, 0],
+                "actions": [0, 0, 1, 1, 0],
+                "beliefs": [[0.5, 0.5]] * 5,
+                "model_parameters": {"B_shape": [2, 2, 2]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_execution_summary(pipeline_output: Path, framework: str) -> None:
+    result_path = (
+        pipeline_output
+        / "12_execute_output"
+        / "demo"
+        / framework
+        / "execution_logs"
+        / f"demo_{framework}_results.json"
+    )
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps({"success": True}), encoding="utf-8")
+    summary_path = (
+        pipeline_output / "12_execute_output" / "summaries" / "execution_summary.json"
+    )
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(
+        json.dumps(
+            {
+                "execution_details": [
+                    {
+                        "framework": framework,
+                        "script_name": f"demo_{framework}.py",
+                        "success": True,
+                        "skipped": False,
+                        "return_code": 0,
+                        "structured_result_file": str(result_path),
+                        "implementation_directory": str(result_path.parents[1]),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )

--- a/src/tests/pipeline/test_cross_framework_reliability.py
+++ b/src/tests/pipeline/test_cross_framework_reliability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -14,7 +15,7 @@ from pipeline.cross_framework_reliability import (
 def test_cross_framework_gate_profiles_all_maintained_backends(
     tmp_path: Path,
 ) -> None:
-    def acceptance_runner(_family: object, output_dir: Path) -> dict[str, object]:
+    def acceptance_runner(_family: object, output_dir: Path) -> dict[str, Any]:
         pipeline_output = output_dir / "basics" / "pipeline_output"
         _write_simulation_payload(pipeline_output, "pymdp")
         _write_execution_summary(pipeline_output, "pymdp")
@@ -40,7 +41,7 @@ def test_cross_framework_gate_profiles_all_maintained_backends(
 def test_cross_framework_gate_fails_missing_step_12_evidence(
     tmp_path: Path,
 ) -> None:
-    def acceptance_runner(_family: object, output_dir: Path) -> dict[str, object]:
+    def acceptance_runner(_family: object, output_dir: Path) -> dict[str, Any]:
         pipeline_output = output_dir / "basics" / "pipeline_output"
         _write_simulation_payload(pipeline_output, "pymdp")
         _write_execution_summary(pipeline_output, "pymdp")
@@ -115,7 +116,7 @@ def test_compare_framework_metrics_fails_missing_seed() -> None:
     assert any(issue.field == "random_seed" for issue in issues)
 
 
-def _acceptance_ledger(name: str, pipeline_output: Path) -> dict[str, object]:
+def _acceptance_ledger(name: str, pipeline_output: Path) -> dict[str, Any]:
     return {
         "schema": "gnn_model_family_acceptance_ledger_v1",
         "status": "passed",

--- a/src/tests/pipeline/test_semantic_fidelity_gate.py
+++ b/src/tests/pipeline/test_semantic_fidelity_gate.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from pipeline.semantic_fidelity import (
+    build_semantic_contract,
+    compare_semantic_contracts,
+    run_semantic_fidelity_gate,
+)
+
+SAMPLE = Path("input/gnn_files/basics/dynamic_perception.md")
+
+
+def test_semantic_contract_contains_release_fields() -> None:
+    contract = build_semantic_contract(SAMPLE)
+
+    assert contract["schema"] == "gnn_semantic_contract_v1"
+    assert contract["model_identity"]["model_name"]
+    assert {variable["name"] for variable in contract["variables"]} >= {"A", "B"}
+    assert contract["edges"]
+    assert "A" in contract["parameter_shapes"]
+    assert contract["contract_hash"]
+
+
+def test_semantic_compare_fails_on_dropped_variable() -> None:
+    original = build_semantic_contract(SAMPLE)
+    changed = deepcopy(original)
+    changed["variables"] = changed["variables"][1:]
+
+    differences = compare_semantic_contracts(original, changed)
+
+    assert any(diff.field == "variables" for diff in differences)
+
+
+def test_semantic_compare_fails_on_lost_edge() -> None:
+    original = build_semantic_contract(SAMPLE)
+    changed = deepcopy(original)
+    changed["edges"] = changed["edges"][1:]
+
+    differences = compare_semantic_contracts(original, changed)
+
+    assert any(diff.field == "edges" for diff in differences)
+
+
+def test_semantic_compare_fails_on_changed_dimension() -> None:
+    original = build_semantic_contract(SAMPLE)
+    changed = deepcopy(original)
+    changed["variables"][0]["dimensions"] = [999]
+
+    differences = compare_semantic_contracts(original, changed)
+
+    assert any(diff.field == "variables" for diff in differences)
+
+
+def test_semantic_compare_fails_on_changed_matrix_shape() -> None:
+    original = build_semantic_contract(SAMPLE)
+    changed = deepcopy(original)
+    changed["parameter_shapes"]["A"] = [1, 1, 1]
+
+    differences = compare_semantic_contracts(original, changed)
+
+    assert any(diff.field == "parameter_shapes" for diff in differences)
+
+
+def test_semantic_gate_writes_passed_ledger(tmp_path: Path) -> None:
+    ledger = run_semantic_fidelity_gate(
+        Path("input/model_family_manifest.json"),
+        tmp_path,
+        family_names=["basics"],
+        strict=True,
+    )
+
+    assert ledger["status"] == "passed"
+    assert (tmp_path / "semantic_fidelity_ledger.json").exists()
+    assert (tmp_path / "semantic_fidelity_ledger.md").exists()
+
+
+def test_semantic_gate_fails_unsupported_success_claim(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Semantic fidelity failed"):
+        run_semantic_fidelity_gate(
+            Path("input/model_family_manifest.json"),
+            tmp_path,
+            family_names=["basics"],
+            formats=("pnml",),
+            strict=True,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1369,7 +1369,7 @@ wheels = [
 
 [[package]]
 name = "generalized-notation-notation"
-version = "1.9.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Release v2.0.0 as the semantic fidelity and cross-framework reliability release.
- Add strict semantic parse/JSON round-trip contracts for maintained model families.
- Add cross-framework reliability ledgers with profiled backend compatibility and a real GridWorld PyMDP/RxInfer/ActiveInference.jl comparison.
- Update roadmap, docs, version metadata, uv lock, and capability-contract guards.

## Validation
- uv run --extra dev python -m pytest src/tests/gnn src/tests/export src/tests/pipeline src/tests/analysis src/tests/report -q -> 764 passed
- uv run --extra dev python scripts/run_semantic_fidelity_gate.py --manifest input/model_family_manifest.json --output-dir /tmp/gnn-semantic-fidelity --strict -> passed
- uv run --extra dev python scripts/run_cross_framework_reliability.py --manifest input/model_family_manifest.json --output-dir /tmp/gnn-cross-framework --strict -> passed
- uv run --extra dev python scripts/run_model_family_acceptance.py --manifest input/model_family_manifest.json --output-dir /tmp/gnn-family-acceptance-all --strict -> passed
- git diff --check -> passed
- ruff check/format-check over changed Python -> passed
- docs audit, GNN doc patterns, maintained-doc terms, repo terminology, capability contracts -> passed
- pytest collect-only with Ollama integration files ignored -> 2411 collected
- full suite with Ollama integration files ignored -> 2393 passed, 17 skipped, 1 xfailed
- tracked output/ restored and clean