### PR TITLE
agent-ergonomics: cold-start spec traversal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,16 @@ The GNN (Generalized Notation Notation) Pipeline is a comprehensive 25-step syst
 
 ---
 
+## Cold Start
+
+New to this repo as an agent? In order:
+
+1. **What this is**: [SPEC.md](SPEC.md) + this file's Overview (25-step GNN pipeline, thin orchestrators).
+2. **Exemplar spec files**: [input/gnn_files/INDEX.md](input/gnn_files/INDEX.md) — every runnable example with a selection table.
+3. **Version map**: [doc/VERSION_MAP.md](doc/VERSION_MAP.md) — release history and version-sensitive surfaces.
+4. **How to verify**: verification commands live in [TO-DO.md](TO-DO.md); doc audits: `uv run python doc/development/docs_audit.py --strict --check-anchors --no-write`.
+---
+
 ## Module Registry
 
 ### Core Processing Modules (Steps 0-9)

--- a/doc/INDEX.md
+++ b/doc/INDEX.md
@@ -6,6 +6,7 @@ short audience map, use [START_HERE.md](START_HERE.md). For curricula, use
 
 ## Start and operate
 
+- [Version map](VERSION_MAP.md)
 - [Documentation hub](README.md)
 - [Setup](SETUP.md)
 - [Configuration](configuration/README.md)
@@ -19,6 +20,7 @@ short audience map, use [START_HERE.md](START_HERE.md). For curricula, use
 
 ## Language
 
+- [Examples index (exemplar spec files)](../../input/gnn_files/INDEX.md)
 - [GNN documentation hub](gnn/README.md)
 - [GNN overview](gnn/gnn_overview.md)
 - [About GNN](gnn/about_gnn.md)

--- a/doc/VERSION_MAP.md
+++ b/doc/VERSION_MAP.md
@@ -1,0 +1,26 @@
+# GNN Version Map
+
+One-stop map of what changed at each release and where the authoritative record
+lives. Current version: **3.1.0** (see `pyproject.toml`, `CHANGELOG.md`).
+
+| Version | Date | Theme | Primary record |
+| --- | --- | --- | --- |
+| 3.1.0 | 2026-08-30 | Release hardening: `GNN_STEP_TIMEOUT_SCALE` for slow-storage checkouts, meta-analysis correctness fix, justfile repair | [CHANGELOG §3.1.0](../CHANGELOG.md) |
+| 3.0.0 | 2026-06-20 | Long-Running Orchestration: durable streams, run sessions, resumable manifests, safe-by-design contracts in `src/pipeline/` | [src/pipeline/AGENTS.md](../../src/pipeline/AGENTS.md) |
+| 2.0.0 | 2026-06-12 | Major architecture revision | [CHANGELOG §2.0.0](../CHANGELOG.md) |
+| 1.x (1.0.0–1.9.0) | 2025-12 → 2026-06 | Initial pipeline through iterative hardening | [CHANGELOG](../CHANGELOG.md) |
+
+## Where version facts live
+
+- **Package version**: `pyproject.toml` (`version` field) — single source of truth.
+- **Release history**: [CHANGELOG.md](../CHANGELOG.md) (Keep-a-Changelog format).
+- **Release process docs**: [releases/README.md](releases/README.md).
+- **Roadmap / next target**: [TO-DO.md](../TO-DO.md) (currently targeting v4.0.0).
+
+## Version-sensitive surfaces (check these after a bump)
+
+- `pyproject.toml` `version`
+- `CHANGELOG.md` release heading + compare links
+- `CITATION.cff`
+- `TO-DO.md` "Current Version" line
+- Release test-evidence claims in `doc/releases/`

--- a/input/gnn_files/INDEX.md
+++ b/input/gnn_files/INDEX.md
@@ -1,0 +1,87 @@
+# GNN Examples Index
+
+Cold-start index of the exemplar GNN spec files under `input/gnn_files/`. Each
+entry is a runnable Active Inference generative model spec: parse it, render it,
+execute it through the 25-step pipeline. For syntax and file-structure rules see
+[normative syntax](../../../doc/gnn/gnn_syntax.md) and the tutorials in
+[doc/gnn/tutorials/](../../../doc/gnn/tutorials/).
+
+**Counts (measured 2026-08-31):** 32 runnable `.md` spec files across 9 task
+folders (plus non-spec `AGENTS.md`/`README.md` scaffolds in
+`pomdp_gridworld/` and `pymdp_scaling_study/`). `../README.md` records
+29/29 render+execute under RxInfer.jl for the core exemplar set (the 3 scaling
+study files are load variants of the same model family).
+
+## Choosing an example
+
+| If you want to… | Start with |
+| --- | --- |
+| Learn GNN syntax from scratch | `basics/static_perception.md` → `basics/dynamic_perception.md` |
+| Run a minimal discrete-state agent | `discrete/simple_mdp.md` → `discrete/tmaze_epistemic.md` |
+| See a canonical full Active Inference agent | `discrete/actinf_pomdp_agent.md` |
+| Compare render targets / scaling | `pymdp_scaling_study/pymdp_scaling_N4_T100.md` (then N8…N64) |
+| Continuous-time / predictive coding | `continuous/predictive_coding_agent.md` |
+| Multi-agent & stigmergy (v3+ features) | `multiagent/stigmergic_swarm.md` |
+| Hierarchical / deep temporal models | `hierarchical/hierarchical_pomdp.md` |
+| Parameter learning | `learning/dirichlet_likelihood_learning.md` |
+| Precision & curiosity mechanisms | `precision/precision_weighted.md`, `precision/curiosity_driven_agent.md` |
+| Causal models (bnlearn export) | `discrete/bnlearn_causal_model.md` |
+
+## Full exemplar set
+
+### basics/
+- [dynamic_perception.md](basics/dynamic_perception.md)
+- [static_perception.md](basics/static_perception.md)
+
+### continuous/
+- [continuous_navigation.md](continuous/continuous_navigation.md)
+- [predictive_coding_agent.md](continuous/predictive_coding_agent.md)
+- [stochastic_dynamics.md](continuous/stochastic_dynamics.md)
+
+### discrete/
+- [actinf_pomdp_agent.md](discrete/actinf_pomdp_agent.md)
+- [bnlearn_causal_model.md](discrete/bnlearn_causal_model.md)
+- [deep_planning_horizon.md](discrete/deep_planning_horizon.md)
+- [hmm_baseline.md](discrete/hmm_baseline.md)
+- [markov_chain.md](discrete/markov_chain.md)
+- [multi_armed_bandit.md](discrete/multi_armed_bandit.md)
+- [simple_mdp.md](discrete/simple_mdp.md)
+- [time_varying_dynamics.md](discrete/time_varying_dynamics.md)
+- [tmaze_epistemic.md](discrete/tmaze_epistemic.md)
+- [two_state_bistable.md](discrete/two_state_bistable.md)
+
+### hierarchical/
+- [hierarchical_pomdp.md](hierarchical/hierarchical_pomdp.md)
+- [temporal_hierarchy.md](hierarchical/temporal_hierarchy.md)
+
+### learning/
+- [dirichlet_likelihood_learning.md](learning/dirichlet_likelihood_learning.md)
+
+### multiagent/
+- [multi_agent_coordination.md](multiagent/multi_agent_coordination.md)
+- [stigmergic_swarm.md](multiagent/stigmergic_swarm.md)
+
+### pomdp_gridworld/
+- [pomdp_gridworld_3x3.md](pomdp_gridworld/pomdp_gridworld_3x3.md)
+- folder docs: [AGENTS.md](pomdp_gridworld/AGENTS.md), [README.md](pomdp_gridworld/README.md)
+
+### precision/
+- [curiosity_driven_agent.md](precision/curiosity_driven_agent.md)
+- [precision_weighted.md](precision/precision_weighted.md)
+
+### pymdp_scaling_study/
+- [pymdp_scaling_N4_T100.md](pymdp_scaling_study/pymdp_scaling_N4_T100.md)
+- [pymdp_scaling_N8_T100.md](pymdp_scaling_study/pymdp_scaling_N8_T100.md)
+- [pymdp_scaling_N16_T100.md](pymdp_scaling_study/pymdp_scaling_N16_T100.md)
+- [pymdp_scaling_N32_T100.md](pymdp_scaling_study/pymdp_scaling_N32_T100.md)
+- [pymdp_scaling_N64_T100.md](pymdp_scaling_study/pymdp_scaling_N64_T100.md)
+- folder docs: [README.md](pymdp_scaling_study/README.md)
+
+### structured/
+- [factorized_posterior.md](structured/factorized_posterior.md)
+
+## Running an example
+
+```bash
+uv run python src/main.py --target-dir input/gnn_files/discrete --output-dir output
+```


### PR DESCRIPTION
- Examples index + version map + cold-start block in AGENTS
- Gates: rewrite_readme regenerate --check (1699 current), validate_documentation --strict 30/30, validate_skills --check-xrefs 45/45