### PR TITLE
ci: scope CodeQL extraction to analysis-relevant sources (fix post-bnlearn analyze deaths)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,29 @@
+name: "GNN CodeQL config"
+
+# Scope extraction to analysis-relevant sources. The repository commits large
+# generated artifact trees (output/ alone carries ~295 extracted .py files);
+# extracting them adds no analysis value and pushed the analyze step over the
+# hosted-runner limit (silent mid-extraction death, 3/3 runs after the bnlearn
+# dependency expansion on 2026-09-07, see PR #27 and the fix discussion).
+
+paths-ignore:
+  - output
+  - output/**
+  - outputs
+  - outputs/**
+  - out
+  - out/**
+  - dist
+  - dist/**
+  - build
+  - build/**
+  - cache
+  - cache/**
+  - demo_output
+  - demo_output/**
+  - cascadia_output
+  - cascadia_output/**
+  - del_norte_output
+  - del_norte_output/**
+  - visualizations_output
+  - visualizations_output/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: read
       security-events: write
@@ -43,6 +43,11 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          # No build tracing: the traced walk of the expanded dependency set
+          # (bnlearn/pgmpy landed 2026-09-07) pushed extraction past the
+          # hosted-runner limit. `none` is the supported build mode for Python.
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
## Summary
CodeQL `analyze (python)` died silently mid-extraction on 3/3 runs of bnlearn-including trees (PR #27 branch x2 + the merged-main push run `34169981452`), while the pre-bnlearn tree completed cleanly (31m13s, run `34163627377`). This PR scopes CodeQL to analysis-relevant sources and removes the traced build walk that correlates with the deaths.

## Changes
- **`.github/codeql/codeql-config.yml`** (new): `paths-ignore` for committed generated trees — `output/` alone carries ~295 `.py` files the analyzer was extracting (`output/11_render_output/**` observed in the death logs); also `outputs/`, `out/`, `dist/`, `build/`, `cache/`, `demo_output/`, `cascadia_output/`, `del_norte_output/`, `visualizations_output/`.
- **`.github/workflows/codeql.yml`**: `build-mode: none` on the python init (supported build mode; drops the traced walk over the dependency set expanded by bnlearn/pgmpy), `config-file` wired, `timeout-minutes` 45 → 60 headroom.

## Evidence trail (2026-09-07)
| Run | Tree | Event | Result | Death signature |
|---|---|---|---|---|
| `34106332901` + 04:30 twin | 3.3.0 tip | push | failure | silent, mid-extraction |
| `34163627377` | ff1012a4d (pre-bnlearn) | push | **success 31m13s** | — |
| `34167465048` (+rerun) | + bnlearn | pull_request | failure x2 | silent death at 11m47s/19m, `Perform CodeQL Analysis`, zero error lines in 278-557K logs |
| `34169981452` | merged main (+ bnlearn) | push | failure | same silent death |

Verdict: not diff-logic, but capacity — the expanded dependency set (bnlearn→pgmpy) pushed the traced extraction over the hosted-runner limit. `build-mode: none` + trimmed extraction paths remove both suspects. Config-only; no source changes.

## Verification
- Both YAML files parse; workflow init step carries `languages` + `build-mode: none` + `config-file`.
- This PR's own CodeQL run is the acceptance test: green here → merge → green on the main push run.