### PR TITLE
docs: accuracy pass on the renamed validate surface; scope pipeline_validator follow-up

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -67,6 +67,14 @@ per PR).
   resolved identically (only requires-dist metadata moved; zero package
   pins changed). Remaining cosmetic floors (networkx 2.6, plotly 5.15,
   scipy 1.7, ...) can follow at the next deliberate lock refresh.
+- `gnn/utils/pipeline_validator.py` vs `gnn/pipeline/pipeline_validator.py`
+  near-name collision (recorded during the MAJ-05 validate-surface pass;
+  unrelated to the `validate_gnn*` function surface, which is resolved):
+  audit both modules' roles and repo-wide consumers, then rename the
+  lower-traffic module to an unambiguous name with a compatibility re-export
+  of the old import path. Verify: import-site grep updated with zero
+  stragglers, `uv run --extra dev mypy src` clean, MCP tools and CLI paths
+  unchanged, module tests green.
 
 ---
 

--- a/docs/gnn/modules/03_gnn.md
+++ b/docs/gnn/modules/03_gnn.md
@@ -117,7 +117,7 @@ success = process_gnn_multi_format(
 - `files` (List[str]): List of processed file paths
 - `processed_files` (List[str]): List of successfully processed files
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `process_gnn_directory_lightweight(target_dir: Path, output_dir: Path = None, recursive: bool = False) -> Dict[str, Any]`
 
@@ -140,7 +140,7 @@ success = process_gnn_multi_format(
 - `parsed_files` (List[Dict]): List of parsed file information
 - `validation_results` (List[Dict]): List of validation results
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `discover_gnn_files(directory: Union[str, Path], recursive: bool = True) -> List[Path]`
 
@@ -157,15 +157,16 @@ success = process_gnn_multi_format(
 
 **Pipeline Step 3 (`process_gnn_multi_format`)** uses a **broader** extension list in `multi_format_processor.py` (e.g. `.json`, `.yaml`, `.lean`, …) so interchange artifacts on disk are found and re-processed. See [SPEC.md](../../../src/gnn/SPEC.md) § File discovery.
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
-#### `parse_gnn_file(file_path: Union[str, Path]) -> Dict[str, Any]`
+#### `parse_gnn_file(file_path: Union[str, Path], content: Optional[str] = None) -> Dict[str, Any]`
 
 **Description**: Parse a single GNN file and extract basic information.
 
 **Parameters**:
 
 - `file_path` (Union[str, Path]): Path to the GNN file
+- `content` (Optional[str]): Pre-read file content; if None the file is opened and read.
 
 **Returns**: `Dict[str, Any]` - Dictionary with parsed information containing:
 
@@ -177,15 +178,16 @@ success = process_gnn_multi_format(
 - `structure_info` (Dict): Structure analysis information
 - `parse_timestamp` (str): Timestamp of parsing
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
-#### `check_gnn_file_structure(file_path: Union[str, Path]) -> Dict[str, Any]`
+#### `check_gnn_file_structure(file_path: Union[str, Path], content: Optional[str] = None) -> Dict[str, Any]`
 
 **Description**: Validate the structure of a GNN file.
 
 **Parameters**:
 
 - `file_path` (Union[str, Path]): Path to the GNN file
+- `content` (Optional[str]): Pre-read file content; if None the file is opened and read.
 
 **Returns**: `Dict[str, Any]` - Dictionary with validation results containing:
 
@@ -196,7 +198,7 @@ success = process_gnn_multi_format(
 - `warnings` (List[str]): List of validation warnings
 - `validation_timestamp` (str): Timestamp of validation
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `generate_gnn_report(processing_results: Dict[str, Any], output_path: Union[str, Path] = None) -> str`
 
@@ -209,7 +211,7 @@ success = process_gnn_multi_format(
 
 **Returns**: `str` - Report content as markdown string
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `get_module_info() -> Dict[str, Any]`
 
@@ -227,7 +229,7 @@ success = process_gnn_multi_format(
 - `supported_formats` (List[str]): List of supported file formats
 - `capabilities` (Dict): Dictionary of capability flags
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `process_gnn(*args, **kwargs) -> Dict[str, Any]`
 
@@ -280,7 +282,7 @@ success = process_gnn_multi_format(
 
 **Returns**: `List[str]` - List of extracted section names
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `_extract_variables_lightweight(content: str) -> List[str]`
 
@@ -292,7 +294,7 @@ success = process_gnn_multi_format(
 
 **Returns**: `List[str]` - List of extracted variable names
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 ---
 

--- a/docs/pymdp/pymdp_pomdp/INTEGRATION_SUMMARY.md
+++ b/docs/pymdp/pymdp_pomdp/INTEGRATION_SUMMARY.md
@@ -175,7 +175,7 @@ python3 src/gnn/12_execute.py --target_dir input/gnn_files/
 ### **Direct PyMDP Execution** 
 ```python
 from gnn.execute.pymdp import execute_pymdp_simulation
-from gnn.gnn import parse_gnn_file
+from gnn import parse_gnn_file
 
 # Parse GNN file
 gnn_spec = parse_gnn_file("input/gnn_files/actinf_pomdp_agent.md")

--- a/docs/troubleshooting/api_error_reference.md
+++ b/docs/troubleshooting/api_error_reference.md
@@ -418,7 +418,7 @@ class ComputationWarning(GNNPerformanceWarning):
 ### Basic Error Handling
 
 ```python
-from gnn.gnn import parse_gnn_file, validate_gnn_file
+from gnn import parse_gnn_file, validate_gnn_file
 from gnn.types import GNSSyntaxError
 
 

--- a/docs/troubleshooting/common_errors.md
+++ b/docs/troubleshooting/common_errors.md
@@ -291,7 +291,7 @@ uv run python src/gnn/5_type_checker.py --target-dir your_model_directory
 
 ```python
 # Python validation script using the real exported validator
-from gnn.gnn import validate_gnn_file
+from gnn import validate_gnn_file
 
 result = validate_gnn_file("your_model.md")
 if not result["is_valid"]:

--- a/docs/troubleshooting/debugging_workflows.md
+++ b/docs/troubleshooting/debugging_workflows.md
@@ -162,7 +162,7 @@ sed -i '1s/^\xEF\xBB\xBF//' your_file.md
 
 ```python
 # Interactive dimension debugging using the real public API
-from gnn.gnn import parse_gnn_file, validate_gnn_file
+from gnn import parse_gnn_file, validate_gnn_file
 
 parsed = parse_gnn_file("your_file.md")
 print("Defined variables:")
@@ -488,7 +488,7 @@ import ipdb  # Enhanced debugger
 
 # Insert breakpoint in code
 def debug_model_parsing(filepath):
-    from gnn.gnn import parse_gnn_file
+    from gnn import parse_gnn_file
 
     # Break here to inspect
     pdb.set_trace()  # or ipdb.set_trace()
@@ -639,7 +639,7 @@ uv run python src/gnn/main.py --only-steps 1,2,3 --target-dir ./models
 uv run python src/gnn/1_setup.py --verbose
 
 # Interactive debugging
-uv run python -c "from gnn.gnn import parse_gnn_file; import pdb; pdb.set_trace(); print(parse_gnn_file('file.md'))"
+uv run python -c "from gnn import parse_gnn_file; import pdb; pdb.set_trace(); print(parse_gnn_file('file.md'))"
 ```
 
 ---

--- a/docs/troubleshooting/error_taxonomy.md
+++ b/docs/troubleshooting/error_taxonomy.md
@@ -186,7 +186,7 @@ uv run python src/gnn/main.py --verbose \
 import pdb
 
 # Inspect model state with the real public API
-from gnn.gnn import parse_gnn_file, validate_gnn_file
+from gnn import parse_gnn_file, validate_gnn_file
 
 parsed = parse_gnn_file("problematic_model.md")
 result = validate_gnn_file("problematic_model.md")

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -519,7 +519,7 @@ goal_weight_01>goal_level_0
 uv pip install jupyter ipywidgets
 
 # Run from the repository root
-from gnn.gnn import parse_gnn_file, validate_gnn_file
+from gnn import parse_gnn_file, validate_gnn_file
 
 # Load and process GNN model
 model = parse_gnn_file('my_model.md')

--- a/src/gnn/AGENTS.md
+++ b/src/gnn/AGENTS.md
@@ -92,7 +92,7 @@ success = process_gnn_multi_format(
 - `files` (List[str]): List of processed file paths
 - `processed_files` (List[str]): List of successfully processed files
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `process_gnn_directory_lightweight(target_dir: Path, output_dir: Path = None, recursive: bool = False) -> Dict[str, Any]`
 
@@ -115,7 +115,7 @@ success = process_gnn_multi_format(
 - `parsed_files` (List[Dict]): List of parsed file information
 - `validation_results` (List[Dict]): List of validation results
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `discover_gnn_files(directory: Union[str, Path], recursive: bool = True) -> List[Path]`
 
@@ -132,15 +132,16 @@ success = process_gnn_multi_format(
 
 **Pipeline Step 3 (`process_gnn_multi_format`)** uses a **broader** extension list in `multi_format_processor.py` (e.g. `.json`, `.yaml`, `.lean`, …) so interchange artifacts on disk are found and re-processed. See [SPEC.md](SPEC.md) § File discovery.
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
-#### `parse_gnn_file(file_path: Union[str, Path]) -> Dict[str, Any]`
+#### `parse_gnn_file(file_path: Union[str, Path], content: Optional[str] = None) -> Dict[str, Any]`
 
 **Description**: Parse a single GNN file and extract basic information.
 
 **Parameters**:
 
 - `file_path` (Union[str, Path]): Path to the GNN file
+- `content` (Optional[str]): Pre-read file content; if None the file is opened and read.
 
 **Returns**: `Dict[str, Any]` - Dictionary with parsed information containing:
 
@@ -152,15 +153,16 @@ success = process_gnn_multi_format(
 - `structure_info` (Dict): Structure analysis information
 - `parse_timestamp` (str): Timestamp of parsing
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
-#### `check_gnn_file_structure(file_path: Union[str, Path]) -> Dict[str, Any]`
+#### `check_gnn_file_structure(file_path: Union[str, Path], content: Optional[str] = None) -> Dict[str, Any]`
 
 **Description**: Validate the structure of a GNN file.
 
 **Parameters**:
 
 - `file_path` (Union[str, Path]): Path to the GNN file
+- `content` (Optional[str]): Pre-read file content; if None the file is opened and read.
 
 **Returns**: `Dict[str, Any]` - Dictionary with validation results containing:
 
@@ -171,7 +173,7 @@ success = process_gnn_multi_format(
 - `warnings` (List[str]): List of validation warnings
 - `validation_timestamp` (str): Timestamp of validation
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `generate_gnn_report(processing_results: Dict[str, Any], output_path: Union[str, Path] = None) -> str`
 
@@ -184,7 +186,7 @@ success = process_gnn_multi_format(
 
 **Returns**: `str` - Report content as markdown string
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `get_module_info() -> Dict[str, Any]`
 
@@ -202,7 +204,7 @@ success = process_gnn_multi_format(
 - `supported_formats` (List[str]): List of supported file formats
 - `capabilities` (Dict): Dictionary of capability flags
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 
 #### `validate_gnn_file(source: Any, *, is_content: bool = False) -> Dict[str, Any]`
@@ -310,7 +312,7 @@ Parsers with semantically richer embedded handling keep their own implementation
 
 **Returns**: `List[str]` - List of extracted section names
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 #### `_extract_variables_lightweight(content: str) -> List[str]`
 
@@ -322,7 +324,7 @@ Parsers with semantically richer embedded handling keep their own implementation
 
 **Returns**: `List[str]` - List of extracted variable names
 
-**Location**: `src/gnn/processor.py`
+**Location**: `src/gnn/processing/processor.py`
 
 ---
 


### PR DESCRIPTION
Follow-up to #31 (MAJ-05). Finishes the doc-surface thread that PR scoped out:

- 18 stale `**Location**: src/gnn/processor.py` lines fixed to `src/gnn/processing/processor.py` in src/gnn/AGENTS.md + docs/gnn/modules/03_gnn.md (v3.3.0 src-move fallout, incl. the MAJ-05-rewritten sections).
- Real `content: Optional[str] = None` kwarg added to the documented signatures of `parse_gnn_file` and `check_gnn_file_structure` (matches processor.py:215/:277).
- 8 stale `from gnn.gnn import` paths normalized to `from gnn import` in 5 troubleshooting docs + pymdp INTEGRATION_SUMMARY. `docs/style_guide.md`'s `gnn.gnn.GNNModel` example deliberately left: that symbol does not exist and needs a rewrite, not a path swap.
- TO-DO: scoped follow-up registered for the `gnn/utils/pipeline_validator.py` vs `gnn/pipeline/pipeline_validator.py` near-name collision (recorded during MAJ-05, untouched there by design).

Verification: 4 doc gates exit 0; harness exit 0 (validate_noncanonical_defs=0, aliases 8/8, doc refs 0).