### PR TITLE
style: ruff format jax_renderer facade (restore format gate on main)

### DIFF
--- a/src/gnn/render/jax/jax_renderer.py
+++ b/src/gnn/render/jax/jax_renderer.py
@@ -136,6 +136,8 @@ def render_gnn_to_jax_combined(
     return _render_to_path(
         _generate_jax_combined_code, "JAX combined", gnn_spec, output_path, options
     )
+
+
 from .jax_combined_generator import (
     _generate_jax_combined_code,
 )


### PR DESCRIPTION
Restores the `ruff format --check src scripts` gate on main: since #33 merged, `src/gnn/render/jax/jax_renderer.py` (the pre-split facade) fails the format check — the mid-file re-export import was left glued to the preceding function. Mechanical whitespace-only fix (two blank lines); zero semantic change.

Note (observed, for maintainers): PR #35 (docs-only) merged while its `test (3.12)` job was red at this same format step, and #33 merged with it red as well — the test/format jobs are evidently not required checks for merge. Suggest gating merges on the format+lint steps or enabling auto-merge with required checks.

Verification: `ruff format --check src scripts` → 640 files already formatted; `ruff check src/gnn scripts` → clean.