### PR TITLE
docs: fix fabricated module paths and stale signatures in reference docs

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -75,6 +75,19 @@ per PR).
   of the old import path. Verify: import-site grep updated with zero
   stragglers, `uv run --extra dev mypy src` clean, MCP tools and CLI paths
   unchanged, module tests green.
+- Stale singular module paths in maintained docs (companion to the
+  `gnn.gnn` import-path fix): ~19 occurrences of `src/gnn/parser.py`,
+  `src/gnn/schema.py`, and `src/gnn/schema_validator.py` across 12 live
+  files (CROSS_REFERENCE_INDEX, docs/README, gnn_syntax, language
+  grammars, 05_type_checker, reference/SPEC, gnn_file_structure_doc,
+  gnn_schema residual sites, gnn_syntax reference, technical_reference,
+  schema_validator AGENTS/README). Real targets are the packages:
+  `src/gnn/schema/parser.py`, `src/gnn/schema_validator/syntax.py` (or
+  `validator.py`), and `src/gnn/parsers/system.py` — map each occurrence
+  to the module that actually defines the named symbol before rewriting;
+  exclude fleet-logs and VERSION_MAP (historical). Verify: repo grep for
+  the three singular paths returns only historical files; docs_audit,
+  gnn_doc_patterns, and maintained_doc_terms gates stay green.
 
 ---
 

--- a/docs/gnn/modules/03_gnn.md
+++ b/docs/gnn/modules/03_gnn.md
@@ -231,23 +231,14 @@ success = process_gnn_multi_format(
 
 **Location**: `src/gnn/processing/processor.py`
 
-#### `process_gnn(*args, **kwargs) -> Dict[str, Any]`
-
-**Description**: Alias for `process_gnn_directory`.
-
-**Parameters**: Same as `process_gnn_directory`
-
-**Returns**: Same as `process_gnn_directory`
-
-**Location**: `src/gnn/__init__.py`
-
-#### `validate_gnn_file(content: str) -> Dict[str, Any]`
+#### `validate_gnn_file(source: Any, *, is_content: bool = False) -> Dict[str, Any]`
 
 **Description**: Validate GNN file content string.
 
 **Parameters**:
 
-- `content` (str): GNN file content as string
+- `source` (str | Path): Path to a GNN file or raw GNN content string
+- `is_content` (bool): If True, treat `source` as raw content regardless of type
 
 **Returns**: `Dict[str, Any]` - Dictionary with validation results:
 
@@ -268,7 +259,7 @@ success = process_gnn_multi_format(
 
 **Returns**: `Tuple[bool, List[str]]` - Tuple of (is_valid, list_of_errors)
 
-**Location**: `src/gnn/parser.py`
+**Location**: `src/gnn/parsers/basic.py`
 
 ### Helper Functions (Internal but Exported)
 

--- a/docs/gnn/reference/gnn_dsl_manual.md
+++ b/docs/gnn/reference/gnn_dsl_manual.md
@@ -131,7 +131,7 @@ This section provides the initial numerical or symbolic values for the variables
 
 **Syntax:**
 
-The content of this section is generally free-form text that describes the parameter settings. While the main parser (`src/gnn/parser.py`) captures this section's content as a single block of text, specific conventions are often followed in practice, as seen in example GNN files. These conventions might involve:
+The content of this section is generally free-form text that describes the parameter settings. While the main parser (`src/gnn/parsers/system.py`) captures this section's content as a single block of text, specific conventions are often followed in practice, as seen in example GNN files. These conventions might involve:
 
 - Comments (`#`) explaining the parameterization logic.
 - Assignments using `=` to set variable values.
@@ -139,7 +139,7 @@ The content of this section is generally free-form text that describes the param
 
 **Parser Behavior:**
 
-- The primary GNN parser (`src/gnn/parser.py`) treats the entire content under `## InitialParameterization` as a text block.
+- The primary GNN parser (`src/gnn/parsers/system.py`) treats the entire content under `## InitialParameterization` as a text block.
 - Downstream tools or specialized parsers might further process this text block to extract specific values based on conventions used within the GNN file.
 
 **Example:**
@@ -167,7 +167,7 @@ The content is typically written in LaTeX format for clear mathematical represen
 
 **Parser Behavior:**
 
-- Similar to `InitialParameterization`, the primary GNN parser (`src/gnn/parser.py`) captures the content of the `## Equations` section as a single block of text.
+- Similar to `InitialParameterization`, the primary GNN parser (`src/gnn/parsers/system.py`) captures the content of the `## Equations` section as a single block of text.
 - Rendering or interpretation of these LaTeX equations is handled by other tools (e.g., for display in documentation or potentially for symbolic processing).
 
 **Example:**
@@ -250,7 +250,7 @@ G=ExpectedFreeEnergy
 
 ### 3.7 Other Standard Sections
 
-The GNN specification includes several other standard sections. The main parser (`src/gnn/parser.py`) generally treats these sections by capturing their content as a block of text under the section name. Their specific meaning and usage are defined by convention and the `src/gnn/documentation/file_structure.md`.
+The GNN specification includes several other standard sections. The main parser (`src/gnn/parsers/system.py`) generally treats these sections by capturing their content as a block of text under the section name. Their specific meaning and usage are defined by convention and the `src/gnn/documentation/file_structure.md`.
 
 - **`ImageFromPaper`**: Contains a link or embedded image of the model's graphical representation from a publication. Content is free-form.
 - **`GNNVersionAndFlags`**: Specifies the GNN version (e.g., `GNN v1`) and any flags affecting interpretation. Content is a text string.

--- a/docs/gnn/reference/gnn_schema.md
+++ b/docs/gnn/reference/gnn_schema.md
@@ -39,7 +39,7 @@ For complete pipeline documentation, see **[src/gnn/AGENTS.md](../../../src/gnn/
 <name>[<dimensions>,type=<type>]
 ```
 
-**Implementation:** `src/gnn/schema.py:parse_state_space()` (strict) / `src/gnn/schema_validator.py:VARIABLE_PATTERN` (permissive)
+**Implementation:** `src/gnn/schema/parser.py:parse_state_space()` (strict) / `src/gnn/schema_validator/syntax.py:VARIABLE_PATTERN` (permissive)
 
 **Schema Rules:**
 
@@ -66,7 +66,7 @@ t[1,type=int]               # scalar, integer type
 <source>><target>    # Directed connection
 ```
 
-**Implementation:** `src/gnn/schema.py:parse_connections()` (strict) / `src/gnn/schema_validator.py:CONNECTION_PATTERN` (permissive)
+**Implementation:** `src/gnn/schema/parser.py:parse_connections()` (strict) / `src/gnn/schema_validator/syntax.py:CONNECTION_PATTERN` (permissive)
 
 **Schema Rules:**
 
@@ -88,10 +88,10 @@ A-o          # A relates to o (undirected)
 ## <SectionName>
 ```
 
-**Implementation:** `src/gnn/schema.py:validate_required_sections()`
+**Implementation:** `src/gnn/schema/parser.py:validate_required_sections()`
 
 **Required sections** — the exact contents of
-`src/gnn/schema.py::REQUIRED_SECTIONS`. A missing one is a hard `GNN-E001`
+`src/gnn/schema/parser.py::REQUIRED_SECTIONS`. A missing one is a hard `GNN-E001`
 error:
 
 - `## GNNSection` - Short, space-free model identifier
@@ -199,7 +199,7 @@ src/gnn/3_gnn.py (thin orchestrator)
 │       ├── VARIABLE_PATTERN (line 59) 
 │       ├── CONNECTION_PATTERN (line 60)
 │       └── PARAMETER_PATTERN (line 62)
-├── src/gnn/parser.py
+├── src/gnn/parsers/system.py
 │   └── GNNParsingSystem (line 72-173)
 │       ├── _detect_format() (line 107)
 │       └── _basic_parser() (line 120)
@@ -286,9 +286,9 @@ src/gnn/11_render.py (thin orchestrator)
 
 ### Schema Validation Chain
 
-1. **Lexical / syntactic**: `src/gnn/schema.py` - section, declaration, and
+1. **Lexical / syntactic**: `src/gnn/schema/parser.py` - section, declaration, and
    connection parsing (there is no separate lexer module)
-2. **Structural**: `src/gnn/parser.py` and `src/gnn/parsers/` - multi-format
+2. **Structural**: `src/gnn/parsers/system.py` and `src/gnn/parsers/` - multi-format
    parsing into the shared model dict
 3. **Semantic**: `src/gnn/type_checker/checking/core.py` - type and dimension validation
 4. **Ontological**: `src/gnn/ontology/processor.py` - domain validation


### PR DESCRIPTION
Continuation of the #35 doc-accuracy pass. All rewrites ground-truthed on disk first (`src/gnn/parser.py`, `src/gnn/schema.py`, `src/gnn/schema_validator.py` do not exist; every target symbol verified at its corrected path):

- **03_gnn.md**: root `validate_gnn_file` now documented with its real signature (`source: Any, *, is_content: bool = False` — mirrors AGENTS.md); `validate_gnn` Location → `parsers/basic.py`; removed the fabricated `process_gnn(*args, **kwargs)` section (`gnn.process_gnn` raises AttributeError — not in the root export map).
- **gnn_schema.md**: 7 stale singular paths → real homes (`schema/parser.py` for parse_state_space/parse_connections/validate_required_sections/REQUIRED_SECTIONS, `schema_validator/syntax.py` for VARIABLE_PATTERN/CONNECTION_PATTERN, `parsers/system.py` for GNNParsingSystem).
- **gnn_dsl_manual.md**: 4 'main parser' refs → `parsers/system.py`.
- **TO-DO**: remaining ~19-site stale singular-path sweep across 12 live files registered as a scoped follow-up (each occurrence needs per-symbol mapping to the module that actually defines it; fleet-logs/VERSION_MAP excluded as historical).

Gates: docs_audit / gnn_doc_patterns / repo_terminology / maintained_doc_terms all exit 0; autoresearch harness exit 0 (validate_noncanonical_defs=0, aliases 8/8, doc refs 0).