### PR TITLE
docs(ledger): MAJ-04 closed - all six modules decomposed, census complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic Ver
 
 ### Changed
 
-- **MAJ-04 (4/6 modules landed): mechanical decomposition via the 3.3.0
-  `execute/processor.py` split pattern.** `analysis/visualizations.py`
+- **MAJ-04 complete (6/6 modules landed): mechanical decomposition via the
+  3.3.0 `execute/processor.py` split pattern.** No tracked `src/gnn` Python
+  file exceeds 2000 lines after the series. `analysis/visualizations.py`
   2412→58 (PR #29: `viz_schema`/`viz_animations`/`viz_manifest`/
   `viz_plots`/`viz_dashboard`), `analysis/analyzer.py` 2031→263 (PR #32:
   `analysis_extraction`/`analysis_statistics`/`analysis_complexity`/
@@ -123,15 +124,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/) and [Semantic Ver
   `jax_factorized_generator`/`jax_model_generator`/`jax_pomdp_generator`/
   `jax_combined_generator`), `render/discopy/translator.py` 2150→303
   (PR #34: `bootstrap`/`gnn_parsing`/`diagram_builders`/`matrix_builders`/
-  `file_translation`/`code_templates`). All moved code byte-identical
-  modulo imports (2347/2001/2190/2108 lines verified per module); facades
-  re-export every moved name (including private helpers and availability
-  constants) so consumer import paths are unchanged; package `__init__`
-  files untouched. Full suite 4263 passed / 0 failed; mypy 0 errors; ruff
-  clean. Remaining MAJ-04 modules (`integration/meta_analysis/visualizer.py`,
-  `testing/test_round_trip.py`) have scoped split plans in TO-DO.md; the
-  shared-subprocess-envelope item is rescoped to the execute side (renderers
-  contain no subprocess code; see the MAJ-04 row).
+  `file_translation`/`code_templates`),
+  `integration/meta_analysis/visualizer.py` 2871→283 (PR #40:
+  `visualizer_style` + `Sweep*PlotMixin`/`SweepExportMixin` siblings —
+  class-method variant preserving byte-identical method moves),
+  `testing/test_round_trip.py` 2214→1356 (PR #43: `round_trip_config`/
+  `round_trip_results`/`round_trip_availability`/`round_trip_markdown_parser`/
+  `round_trip_comparison`/`round_trip_report`). All moved code byte-identical
+  modulo imports (2347/2001/2190/2108/2811/2172 lines verified per module);
+  facades re-export every moved name (including private helpers and
+  availability constants) so consumer import paths are unchanged; package
+  `__init__` files untouched. Full suite green at every PR (4263→4272
+  passed / 0 failed); mypy 0 errors; ruff clean. Session benchmark
+  `oversized_module_lines` 13878 → 0; `gnn_python_lines` +0.6% (code moved,
+  not deleted). The shared-subprocess-envelope item is rescoped to the
+  execute side (renderers contain no subprocess code; see the closed MAJ-04
+  note in TO-DO.md).
 
 ## Deep horizon 2026-09-07 - gnn-maj05-validate-surface
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -31,15 +31,37 @@ shelled out to the retired pre-restructure orchestrator (`main.py` at the
 NameError. Tests: `tests/pipeline/test_health_check.py` and
 `tests/pipeline/test_pipeline_validator.py`.
 
+MAJ-04 closed 2026-09-07: all six >2000-line modules decomposed via the
+3.3.0 `execute/processor.py` split pattern (mechanical sibling extraction,
+facade re-exports preserved, one module per PR) — `analysis/visualizations.py`
+2412→58 (PR #29), `analysis/analyzer.py` 2031→263 (PR #32),
+`render/jax/jax_renderer.py` 2200→170 (PR #33), `render/discopy/translator.py`
+2150→303 (PR #34), `integration/meta_analysis/visualizer.py` 2871→283 (PR #40,
+`Sweep*Mixin` variant preserving byte-identical class-method moves), and
+`testing/test_round_trip.py` 2214→1356 (PR #43, `round_trip_*` siblings).
+Class-method bodies moved verbatim into mixins where module-level extraction
+was impossible. Every facade re-exports every moved name (no consumer
+import-path changes; per-module facade-contract probes 31/34/27/36/13/47
+names), moved code verified byte-identical modulo imports
+(2347/2001/2190/2108/2811/2172 lines), full suite green at every PR
+(4263→4272 passed), mypy/ruff 0 throughout. Session benchmark
+`oversized_module_lines` 13878 → 0: no tracked `src/gnn` Python file exceeds
+2000 lines (`gnn_python_lines` +0.6% across the series — code moved, not
+deleted). The row's "shared subprocess envelope the nine per-framework
+renderers duplicate" item is RESCOPED to its own future work: renderers
+contain zero subprocess code (verified); the duplication is execute-side
+(`rxinfer`/`stan`/`lean`/`activeinference` runners + 4 `executor.py` MCP
+methods vs the canonical `execute_script_safely` at `execute/executor.py:1089-1200`)
+and needs a behavior-preserving refactor with its own tests, not a
+mechanical split.
+
 ## Open Scoped Roadmap
 
 Every item below is cold-startable: scope, files, verification, and acceptance
-are pinned. Rough order: MAJ-05 -> MAJ-06 -> MAJ-04 (largest; one module
-per PR).
+are pinned.
 
 | ID | Scope | Acceptance evidence |
 | --- | --- | --- |
-| MAJ-04 | Decompose the six >2000-line modules via the 3.3.0 `execute/processor.py` split pattern (mechanical extraction into sibling modules, facade re-exports preserved, one module per PR). **LANDED 2026-09-07 (deep-horizon session, 4/6):** `analysis/visualizations.py` 2412→58 (PR #29), `analysis/analyzer.py` 2031→263 (PR #32), `render/jax/jax_renderer.py` 2200→170 (PR #33), `render/discopy/translator.py` 2150→303 (PR #34). **REMAINING:** `integration/meta_analysis/visualizer.py` 2871 — class-method split must preserve byte-identity, so extract `Sweep*PlotMixin` siblings holding verbatim method blocks (runtime/metric/summary/export seams; facade keeps `__init__`, `generate_all`, `_safe_log_scale`, and the `_MPL_AVAILABLE` binding that `tests/integration/test_integration_meta_analysis_validation.py:287-289` monkeypatches); `testing/test_round_trip.py` 2214 — extract config dicts, result dataclasses, `_DirectMarkdownParser`, `_compare_*` helpers, and report writer into `round_trip_*` siblings (non-`test_` names so explicit-path collection is unchanged); facade keeps availability flags, `sys.path.insert`/`setrecursionlimit` side effects, tester core, unittest class. **RESCOPED:** the "shared subprocess envelope the nine per-framework renderers duplicate" — renderers contain zero subprocess code (verified); the duplication is execute-side (`rxinfer/stan/lean/activeinference` runners + 4 `executor.py` MCP methods vs the canonical `execute_script_safely` at `execute/executor.py:1089-1200`) and needs a behavior-preserving refactor with its own tests, not a mechanical split. | Landed modules: no import-path changes (per-module facade-contract probes: 31/34/27/36 names importable), mypy 0 errors, `ruff check src/gnn scripts` clean, targeted module tests green, full suite 4263 passed / 0 failed, moved code byte-identical modulo import lines (2347/2001/2190/2108 verified per module). Session benchmark `oversized_module_lines` 13878 → 5085 (-63.4%). |
 
 
 ### Smaller scoped cleanups (independent of the majors)


### PR DESCRIPTION
Final ledger record for the MAJ-04 deep-horizon decomposition series (PRs #29, #32, #33, #34, #40, #43 — all six >2000-line modules decomposed with byte-identical moves and preserved consumer import paths).

- **TO-DO.md**: MAJ-04 moves to the closed-notes section (MAJ-07 pattern) with the per-PR record, byte-identity and benchmark receipt (`oversized_module_lines` 13878 → 0, `gnn_python_lines` +0.6%), and the subprocess-envelope rescope to execute-side future work. Stale roadmap ordering sentence fixed; open table now empty.
- **CHANGELOG.md**: the `gnn-maj04-modules` subsection records the complete 6/6 series including the mixin variant used for class-based modules 5-6.

Docs-only; no code changes. Full session report: /tmp/gnn-maj04-deep-report.md.