### PR TITLE
docs: complete the stale singular-path sweep; strict doc-path gate; CI wiring

### DIFF
--- a/.github/workflows/local-gates.yml
+++ b/.github/workflows/local-gates.yml
@@ -51,3 +51,6 @@ jobs:
 
       - name: MCP + skills resolvability health gate
         run: uv run --extra dev python scripts/check_mcp_skills_health.py --strict
+
+      - name: Doc path reference gate
+        run: uv run --extra dev python scripts/check_doc_path_references.py

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -75,22 +75,12 @@ per PR).
   of the old import path. Verify: import-site grep updated with zero
   stragglers, `uv run --extra dev mypy src` clean, MCP tools and CLI paths
   unchanged, module tests green.
-- Stale singular module paths in maintained docs (companion to the
-  `gnn.gnn` import-path fix): 21 occurrences (19 lines) of
-  `src/gnn/parser.py`, `src/gnn/schema.py`, and
-  `src/gnn/schema_validator.py` across 12 live files
-  (CROSS_REFERENCE_INDEX, docs/README, gnn_syntax, language grammars,
-  05_type_checker, reference/SPEC, gnn_file_structure_doc, gnn_schema
-  residual sites, gnn_syntax reference, technical_reference,
-  schema_validator AGENTS/README). Real targets are the packages:
-  `src/gnn/schema/parser.py`, `src/gnn/schema_validator/syntax.py` (or
-  `validator.py`), and `src/gnn/parsers/system.py` — map each occurrence
-  to the module that actually defines the named symbol before rewriting;
-  exclude fleet-logs and VERSION_MAP (historical). Regression gate:
-  `uv run python scripts/check_doc_path_references.py` count-caps these
-  citations at the registered 21 — lower the cap as sites are fixed and
-  add it to Verification Commands when the cap reaches 0. Other gates
-  (docs_audit, gnn_doc_patterns, maintained_doc_terms) stay green.
+- Stale singular module paths in maintained docs: RESOLVED 2026-09-08 —
+  all 21 occurrences (19 lines) of `src/gnn/parser.py`, `src/gnn/schema.py`,
+  and `src/gnn/schema_validator.py` re-pointed to their verified real homes
+  (`schema/parser.py`, `schema_validator/syntax.py`, `parsers/system.py`);
+  regression gate `scripts/check_doc_path_references.py` is CI-wired
+  (local-gates) and strict (cap 0).
 
 ---
 
@@ -122,6 +112,7 @@ uv run python docs/development/docs_audit.py --strict --check-anchors --no-write
 uv run python scripts/check_gnn_doc_patterns.py --strict
 uv run python scripts/check_maintained_doc_terms.py --strict
 uv run python scripts/check_repo_terminology.py --strict
+uv run python scripts/check_doc_path_references.py
 uv run python scripts/check_capability_contracts.py
 uv run python scripts/run_semantic_fidelity_gate.py --output-dir /tmp/semantic_fidelity --strict
 uv run python scripts/run_cross_framework_reliability.py --output-dir /tmp/cross_framework --strict

--- a/docs/CROSS_REFERENCE_INDEX.md
+++ b/docs/CROSS_REFERENCE_INDEX.md
@@ -59,7 +59,7 @@ for the current render/execute split.
 - Pipeline order: `src/gnn/pipeline/step_registry.py`
 - CLI options: `src/gnn/utils/arg_parsing.py` and `src/gnn/cli/__init__.py`
 - Automatic YAML path: `input/config.yaml` and `src/gnn/utils/config_loader.py`
-- Required GNN sections: `src/gnn/schema.py`
+- Required GNN sections: `src/gnn/schema/parser.py`
 - Render inventory: `src/gnn/render/framework_registry.py`
 - Execute inventory: `src/gnn/execute/processor.py::parse_frameworks_parameter`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,7 +150,7 @@ See [Framework Integrations](gnn/integration/framework_integration_guide.md).
   run.
 - Keep generated pipeline artifacts under `output/`; do not treat them as maintained
   documentation.
-- Keep the GNN syntax examples aligned with `src/gnn/schema.py` and validate examples
+- Keep the GNN syntax examples aligned with `src/gnn/schema/parser.py` and validate examples
   with `gnn validate` or Step 5 before publishing them.
 
 For versioning policy, see [SPEC.md](SPEC.md). For contribution conventions, see

--- a/docs/gnn/gnn_syntax.md
+++ b/docs/gnn/gnn_syntax.md
@@ -25,7 +25,7 @@ introduced by a level-2 header (`## SectionName`).
 
 Two code paths are used in this repository:
 
-- **Strict schema validator**: `src/gnn/schema.py` enforces required sections, declaration formats, and connection grammar.
+- **Strict schema validator**: `src/gnn/schema/parser.py` enforces required sections, declaration formats, and connection grammar.
 - **Permissive markdown parser**: `src/gnn/parsers/markdown_parser.py` is more tolerant when loading mixed or partially structured markdown.
 
 For CI, type-checking, and pipeline validation, prefer examples that satisfy the strict schema validator.
@@ -292,12 +292,12 @@ by Step 10. Note the conventional binding: `A` is the **likelihood**
 |------------|---------|
 | `GNN-E001` | Missing required section |
 | `GNN-E002` | Variable dimension mismatch (declaration vs parameterization) |
-| `GNN-E003` | Unknown variable in connection (**reserved, not yet enforced** — `src/gnn/schema.py` reports this condition as the `GNN-W002` warning instead) |
+| `GNN-E003` | Unknown variable in connection (**reserved, not yet enforced** — `src/gnn/schema/parser.py` reports this condition as the `GNN-W002` warning instead) |
 | `GNN-E004` | Duplicate variable declaration |
 | `GNN-E005` | Unparseable connection syntax |
 
 | Warning Code | Meaning |
 |--------------|---------|
-| `GNN-W001` | Variable declared but never used in connections (**planned, not yet enforced** — no emitting code in `src/gnn/schema.py`) |
+| `GNN-W001` | Variable declared but never used in connections (**planned, not yet enforced** — no emitting code in `src/gnn/schema/parser.py`) |
 | `GNN-W002` | Connection references undeclared variable |
 | `GNN-W003` | Parameterization provided for undeclared variable |

--- a/docs/gnn/language/gnn_connection_grammar.md
+++ b/docs/gnn/language/gnn_connection_grammar.md
@@ -52,14 +52,14 @@ s>o:emission                  # state to observation emission
 An undeclared endpoint is reported as a **warning**, not an error: parsing
 continues and the edge is kept. `GNN-E003` is reserved for this condition in
 the error taxonomy but has no emitting code — `parse_connections` in
-[`src/gnn/schema.py`](../../../src/gnn/schema/__init__.py) raises `GNN-W002` for both
+[`src/gnn/schema/parser.py`](../../../src/gnn/schema/__init__.py) raises `GNN-W002` for both
 endpoints instead. Cross-validation only happens when the parser is given the
 declared-variable set; parsing a `Connections` block in isolation reports
 neither code.
 
 ## Implementation
 
-- Parser: [`src/gnn/schema.py :: parse_connections()`](../../../src/gnn/schema/__init__.py)
+- Parser: [`src/gnn/schema/parser.py :: parse_connections()`](../../../src/gnn/schema/__init__.py)
 - LSP diagnostics: [`src/gnn/lsp/__init__.py`](../../../src/gnn/lsp/__init__.py) — real-time connection error highlighting
 - CLI: `gnn validate <file.md>` runs all connection grammar checks
 

--- a/docs/gnn/language/gnn_variable_grammar.md
+++ b/docs/gnn/language/gnn_variable_grammar.md
@@ -45,8 +45,8 @@ B[3,3,3, type=float, default=ones]        # 3D tensor, ones
 
 ## Implementation
 
-- Parser: [`src/gnn/schema.py :: parse_state_space()`](../../../src/gnn/schema/__init__.py)
-- Validator: [`src/gnn/schema.py :: validate_matrix_dimensions()`](../../../src/gnn/schema/__init__.py)
+- Parser: [`src/gnn/schema/parser.py :: parse_state_space()`](../../../src/gnn/schema/__init__.py)
+- Validator: [`src/gnn/schema/parser.py :: validate_matrix_dimensions()`](../../../src/gnn/schema/__init__.py)
 - CLI: `gnn validate <file.md>` runs all variable grammar checks
 
 ---

--- a/docs/gnn/modules/05_type_checker.md
+++ b/docs/gnn/modules/05_type_checker.md
@@ -68,7 +68,7 @@ python src/gnn/5_type_checker.py --target-dir input/gnn_files \
 
 The type checker itself emits one code, `GNN-E004` (matrix dimensions mismatch the
 declared shape). The remaining codes come from the schema validator in
-`src/gnn/schema.py`; their normative meanings are in
+`src/gnn/schema/parser.py`; their normative meanings are in
 [gnn_syntax.md § 8 Error Taxonomy](../gnn_syntax.md) and are summarised here:
 
 | Rule ID | Emitted by | Meaning | Default Severity |

--- a/docs/gnn/reference/SPEC.md
+++ b/docs/gnn/reference/SPEC.md
@@ -26,7 +26,7 @@ specification disagree, the specification wins and the file here is the bug.
 
 ## Status
 Maintained. Every file in this subtree is referenced from `docs/gnn/README.md`
-and should remain consistent with `src/gnn/schema.py` and
+and should remain consistent with `src/gnn/schema/parser.py` and
 `src/gnn/parsers/markdown_parser.py`. A change to the normative syntax must
 update [`docs/gnn/gnn_syntax.md`](../gnn_syntax.md), the parser, and the
 affected pages here in the same change.

--- a/docs/gnn/reference/gnn_file_structure_doc.md
+++ b/docs/gnn/reference/gnn_file_structure_doc.md
@@ -77,7 +77,7 @@ A complete GNN file includes the following sections in this order. Section
 headers are single CamelCase tokens with no spaces — `## StateSpaceBlock`,
 never `## State space block`. Five of them (`GNNSection`,
 `GNNVersionAndFlags`, `ModelName`, `StateSpaceBlock`, `Connections`) are
-enforced by `src/gnn/schema.py::REQUIRED_SECTIONS`; the rest are expected by
+enforced by `src/gnn/schema/parser.py::REQUIRED_SECTIONS`; the rest are expected by
 downstream pipeline steps but not rejected in their absence. See the
 obligation table in [`gnn_syntax.md`](gnn_syntax.md#canonical-section-inventory).
 

--- a/docs/gnn/reference/gnn_schema.md
+++ b/docs/gnn/reference/gnn_schema.md
@@ -12,7 +12,7 @@ Complete specification for GNN syntax parsing and validation.
 GNN schema validation is handled by multiple pipeline steps:
 
 - **`src/gnn/3_gnn.py`** → GNN file parsing and schema validation
-  - Implementation: `src/gnn/schema_validator.py`
+  - Implementation: `src/gnn/schema_validator/syntax.py`
   - See: **[src/gnn/AGENTS.md](../../../src/gnn/AGENTS.md)**
 - **`src/gnn/5_type_checker.py`** → Type and dimensional validation
   - Implementation: `src/gnn/type_checker/checking/core.py` (`GNNTypeChecker`)
@@ -193,7 +193,7 @@ Framework targets:
 ```text
 src/gnn/3_gnn.py (thin orchestrator)
 ├── src/gnn/multi_format_processor.py (main processor)
-├── src/gnn/schema_validator.py
+├── src/gnn/schema_validator/syntax.py
 │   └── GNNParser (line 54-89)
 │       ├── SECTION_PATTERN (line 58)
 │       ├── VARIABLE_PATTERN (line 59) 

--- a/docs/gnn/reference/gnn_syntax.md
+++ b/docs/gnn/reference/gnn_syntax.md
@@ -30,7 +30,7 @@ For complete pipeline documentation, see **[src/gnn/AGENTS.md](../../../src/gnn/
 A valid GNN file uses the following sections in the order below. Two distinct
 levels of obligation apply, and it is worth keeping them apart:
 
-- **Enforced** — listed in `src/gnn/schema.py::REQUIRED_SECTIONS`. Absence is
+- **Enforced** — listed in `src/gnn/schema/parser.py::REQUIRED_SECTIONS`. Absence is
   a hard error: `validate_required_sections` emits `GNN-E001`
   (*missing required section*) and the file fails type checking.
 - **Expected** — not checked by the validator, but every sample in

--- a/docs/gnn/reference/technical_reference.md
+++ b/docs/gnn/reference/technical_reference.md
@@ -62,7 +62,7 @@ All pipeline steps follow the thin orchestrator pattern. Each step is documented
 **Key Parsing Patterns:**
 
 ```python
-# src/gnn/schema_validator.py:58-63 (actual regex patterns)
+# src/gnn/schema_validator/syntax.py:58-63 (actual regex patterns)
 SECTION_PATTERN = re.compile(r"^## (.+)$")
 VARIABLE_PATTERN = re.compile(
     r"^([\w_π][\w\d_π]*)(\[([^\]]+)\])?(?:,type=([a-zA-Z]+))?(?:\s*#\s*(.*))?$"
@@ -286,7 +286,7 @@ Step 11 (Render) → generated framework code
 #### Parsing System
 
 - **Main Interface:** `src/gnn/multi_format_processor.py`
-- **Schema Validation:** `src/gnn/schema_validator.py:GNNParser` (line 54)
+- **Schema Validation:** `src/gnn/schema_validator/syntax.py:GNNParser` (line 54)
 - **Multi-format Support:** `src/gnn/parsers/` directory
   - `markdown_parser.py`: Standard GNN markdown format
   - `python_parser.py`: Neural network implementations (line 25)

--- a/scripts/check_doc_path_references.py
+++ b/scripts/check_doc_path_references.py
@@ -64,7 +64,7 @@ RESIDUE_PATHS = (
 
 # Citation count at sweep registration (see TO-DO). Exceeding this means a
 # NEW stale citation appeared. Lower as the sweep fixes sites; 0 = strict.
-REGISTERED_RESIDUE_COUNT = 21
+REGISTERED_RESIDUE_COUNT = 0
 
 
 def iter_doc_files() -> Iterator[Path]:

--- a/src/gnn/formal_specs/README.md
+++ b/src/gnn/formal_specs/README.md
@@ -8,7 +8,7 @@ This directory contains formal mathematical specifications of GNN (Generalized N
 
 The formal specifications serve three roles:
 
-1. **Mathematical Foundation** — Provide precise definitions of GNN constructs (variables, connections, state spaces) that ground the Python implementation in `src/gnn/parsers/basic.py` and `src/gnn/types.py`.
+1. **Mathematical Foundation** — Provide precise definitions of GNN constructs (variables, connections, state spaces) that ground the Python implementation in `src/gnn/parsers/basic.py` and `src/gnn/types/`.
 2. **Property Verification** — Express and (where tooling permits) verify invariants such as matrix dimension consistency, probability normalization, and well-formedness of POMDP structures.
 3. **Cross-Language Reference** — Offer templates for researchers who need to interface GNN models with theorem provers or symbolic computation environments.
 

--- a/src/gnn/schema_validator/AGENTS.md
+++ b/src/gnn/schema_validator/AGENTS.md
@@ -18,8 +18,8 @@
 
 ## Module Structure
 
-Three concerns, one package (split from the former single-file
-`src/gnn/schema_validator.py` plus `src/gnn/cross_format_validator.py` in 3.2.0):
+Three concerns, one package (split in 3.2.0 from a former single-file
+validator module plus a standalone cross-format module):
 
 1. `syntax.py` — `GNNParser`: regex-based parsing of GNN source text into a
    `ParsedGNN` structure. No validation policy; parsing only.
@@ -32,7 +32,8 @@ Three concerns, one package (split from the former single-file
    consistency checks across the rendered output formats.
 
 Shared types (`ValidationLevel`, `ValidationResult`, `ParsedGNN`) come from
-`src/gnn/types.py`; the package `__init__.py` re-exports them for convenience.
+`src/gnn/types/` (definitions in `definitions.py`); the package `__init__.py`
+re-exports them for convenience.
 
 ## Agent Guidance
 

--- a/src/gnn/schema_validator/README.md
+++ b/src/gnn/schema_validator/README.md
@@ -2,10 +2,9 @@
 
 Syntax-level validation and parsing for GNN model files: a regex-based parser, a
 multi-level validator with round-trip and schema checks, and cross-format
-consistency verification. This package was split in 3.2.0 from the former
-single-file `src/gnn/schema_validator.py` (parser half → `syntax.py`,
-validation half → `validator.py`) plus `src/gnn/cross_format_validator.py`
-(→ `cross_format.py`).
+consistency verification. The package was split in 3.2.0 from a former
+single-file module (parser half → `syntax.py`, validation half →
+`validator.py`) plus a standalone cross-format module (→ `cross_format.py`).
 
 ## Module Structure
 
@@ -47,7 +46,7 @@ Notes:
   removed); `ROUND_TRIP_AVAILABLE` reflects whether `gnn.parsers` imports
   cleanly. `GNNValidator` degrades accordingly.
 - `ValidationLevel`, `ValidationResult`, and `ParsedGNN` live in
-  `src/gnn/types.py` and are re-exported here for convenience.
+  `src/gnn/types/` and are re-exported here for convenience.
 
 ## See Also
 

--- a/src/gnn/testing/round_trip_markdown_parser.py
+++ b/src/gnn/testing/round_trip_markdown_parser.py
@@ -20,7 +20,6 @@ from .round_trip_availability import GNNInternalRepresentation
 logger = logging.getLogger(__name__)
 
 
-
 class _DirectMarkdownParser:
     """A simple, robust markdown parser that doesn't rely on complex validation."""
 

--- a/src/gnn/testing/round_trip_report.py
+++ b/src/gnn/testing/round_trip_report.py
@@ -18,7 +18,6 @@ from .round_trip_results import ComprehensiveTestReport
 logger = logging.getLogger(__name__)
 
 
-
 class RoundTripReportMixin:
     """Verbatim methods moved from ``GNNRoundTripTester``."""
 

--- a/src/gnn/testing/test_round_trip.py
+++ b/src/gnn/testing/test_round_trip.py
@@ -111,7 +111,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 logger = logging.getLogger(__name__)
 
 
-
 class GNNRoundTripTester(RoundTripComparisonMixin, RoundTripReportMixin):
     """Comprehensive round-trip testing system for GNN formats."""
 
@@ -1148,7 +1147,6 @@ class GNNRoundTripTester(RoundTripComparisonMixin, RoundTripReportMixin):
                 )
 
         return result
-
 
     def _get_file_extension(self, format: GNNFormat) -> str:
         """Get file extension for a format."""


### PR DESCRIPTION
Completes the TO-DO stale-path sweep (21 occurrences / 19 lines → 0) and makes the #42 gate strict + CI-wired.

**Per-symbol mapping (every target verified on disk before rewriting):**
- `src/gnn/schema.py` → `schema/parser.py`: parse_state_space (:165), parse_connections (:64), validate_matrix_dimensions (:377), REQUIRED_SECTIONS/validate_required_sections (:564/:573), GNN-W002 raise sites (:116/:126) — 13 sites across 9 files.
- `src/gnn/schema_validator.py` → `schema_validator/syntax.py`: GNNParser (:37), VARIABLE/CONNECTION/PARAMETER patterns (:42-:47) — 6 sites (incl. rewriting the README/AGENTS 3.2.0 split narratives to describe the current layout without citing dead paths).
- `src/gnn/types.py` → `types/` package (definitions.py) — 3 bonus sites, same disease, verified.
- `src/gnn/parser.py` / `cross_format_validator.py`: already at zero after #39/#42.

**Gate**: residue cap 21 → **0** (strict) in `scripts/check_doc_path_references.py`; wired into `.github/workflows/local-gates.yml` (Doc path reference gate step) so recurrence fails CI instead of rotting.

**Also**: formats the three testing-split siblings (b1470a3b8 merged after #42's CI started — the recurring merge-preview format gap, third instance).

**Verification**: doc-path gate 0/0 strict; docs_audit / gnn_doc_patterns / maintained_doc_terms / repo_terminology exit 0; ruff format+check whole-tree clean; harness exit 0 (validate_noncanonical_defs=0, aliases 8/8).