### PR TITLE
refactor(lint): narrow the global F401/F811 policy ignore into targeted per-file-ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,13 +448,29 @@ ignore = [
     "C408",  # unnecessary dict call
     "C414",  # unnecessary double cast / process
     "C416",  # unnecessary comprehension
-    "F811",  # redefined while unused
-    "F401",  # unused import (optional deps, import-or-skip probes, test adapters)
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**" = ["F401"]
+
+# Facade re-export surfaces (MAJ-04 mechanical splits): these modules import
+# moved names purely to preserve consumer import paths. Every name in each
+# facade's re-export block is part of the module's public surface.
+"src/gnn/analysis/visualizations.py" = ["F401"]
+"src/gnn/analysis/analyzer.py" = ["F401"]
+"src/gnn/render/jax/jax_renderer.py" = ["F401"]
+"src/gnn/render/discopy/translator.py" = ["F401"]
+"src/gnn/integration/meta_analysis/visualizer.py" = ["F401"]
+"src/gnn/integration/meta_analysis/visualizer_style.py" = ["F401"]
+"src/gnn/testing/test_round_trip.py" = ["F401"]
+"src/gnn/testing/round_trip_availability.py" = ["F401"]
+"src/gnn/execute/processor.py" = ["F401"]
+
+# Guarded optional-dependency probes: parsers import serialization backends
+# inside try/except to test availability; the binding itself is intentionally
+# unused (usage is gated on the availability flag).
+"src/gnn/parsers/*" = ["F401"]
 
 # CVE-2026-4539 resolved: Pygments 2.20.0 (released 2026-03-29) includes the
 # official fix for the AdlLexer ReDoS (pygments/pygments#3064).  The git-fork

--- a/scripts/check_pomdp_gridworld_outputs.py
+++ b/scripts/check_pomdp_gridworld_outputs.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any

--- a/scripts/lib/shared.py
+++ b/scripts/lib/shared.py
@@ -4,9 +4,8 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
-from typing import FrozenSet, List, Optional, Set
+from typing import FrozenSet, Optional, Set
 
 
 def repo_root() -> Path:

--- a/scripts/run_pymdp_gnn_scaling_analysis.py
+++ b/scripts/run_pymdp_gnn_scaling_analysis.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import argparse
 import errno
 import json
-import logging
 import os
 import shutil
 import subprocess
@@ -32,7 +31,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, NamedTuple
 
 import yaml
 
@@ -45,7 +44,7 @@ from pymdp_spec_generator import (  # type: ignore[import-not-found]
     generate_gnn_file,
 )
 
-from gnn.utils.visual_logging import VisualConfig, create_visual_logger
+from gnn.utils.visual_logging import create_visual_logger
 
 # Default sweep grid
 DEFAULT_N_VALUES = [2, 4, 8, 16]

--- a/scripts/verify_logging_duplication.py
+++ b/scripts/verify_logging_duplication.py
@@ -5,7 +5,6 @@ Public functions: verify_duplication
 """
 
 import io
-import logging
 import sys
 from pathlib import Path
 from typing import Any

--- a/src/gnn/advanced_visualization/mcp.py
+++ b/src/gnn/advanced_visualization/mcp.py
@@ -5,7 +5,6 @@ This module exposes advanced visualization processing tools via MCP.
 """
 
 import logging
-from pathlib import Path
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)

--- a/src/gnn/analysis/activeinference_jl/analyzer.py
+++ b/src/gnn/analysis/activeinference_jl/analyzer.py
@@ -258,7 +258,7 @@ def create_trace_reconstruction(csv_path: Path, output_dir: Path) -> List[str]:
         List of generated file paths
     """
     try:
-        from ..viz_base import MATPLOTLIB_AVAILABLE, np, plt
+        from ..viz_base import MATPLOTLIB_AVAILABLE, plt
     except ImportError:
         return []
 

--- a/src/gnn/analysis/pymdp/visualizer.py
+++ b/src/gnn/analysis/pymdp/visualizer.py
@@ -25,7 +25,7 @@ warnings.filterwarnings("ignore")
 
 # Import shared visualization utilities (centralized matplotlib setup)
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ..viz_base import MATPLOTLIB_AVAILABLE, np, plt
 

--- a/src/gnn/analysis/rxinfer/gif_animator.py
+++ b/src/gnn/analysis/rxinfer/gif_animator.py
@@ -16,7 +16,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import matplotlib
 

--- a/src/gnn/api/app.py
+++ b/src/gnn/api/app.py
@@ -14,7 +14,6 @@ Requires: pip install fastapi uvicorn
 """
 
 import asyncio
-import json
 import logging
 import os
 import sys
@@ -22,14 +21,13 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse, StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 FASTAPI_AVAILABLE = True
 

--- a/src/gnn/api/processor.py
+++ b/src/gnn/api/processor.py
@@ -15,7 +15,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/gnn/audio/effects.py
+++ b/src/gnn/audio/effects.py
@@ -15,7 +15,7 @@ Use :func:`apply_effects_chain` to compose several effects by name.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Callable, cast
+from typing import Any, Callable
 
 import numpy as np
 

--- a/src/gnn/audio/generator.py
+++ b/src/gnn/audio/generator.py
@@ -6,7 +6,7 @@ This module provides audio generation functionality.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 

--- a/src/gnn/audio/processor.py
+++ b/src/gnn/audio/processor.py
@@ -40,7 +40,6 @@ from .streaming import (
     frames_from_execution_trace,
     write_stream_summary,
 )
-from .validation import coerce_audio_array, require_sample_rate
 
 
 def process_audio(

--- a/src/gnn/audio/validation.py
+++ b/src/gnn/audio/validation.py
@@ -14,7 +14,7 @@ Error messages are part of the contract — existing tests pin the substrings
 from __future__ import annotations
 
 import math
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 

--- a/src/gnn/execute/activeinference_jl/activeinference_runner.py
+++ b/src/gnn/execute/activeinference_jl/activeinference_runner.py
@@ -15,7 +15,6 @@ Features:
 
 import json
 import logging
-import os
 import subprocess  # nosec B404
 import sys
 import time

--- a/src/gnn/execute/jax/kronecker_factorized.py
+++ b/src/gnn/execute/jax/kronecker_factorized.py
@@ -37,7 +37,7 @@ The Kronecker identities are pinned by ``tests/execute/test_kronecker_factorized
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Sequence
 
 import jax.numpy as jnp

--- a/src/gnn/execute/pymdp/pymdp_utils.py
+++ b/src/gnn/execute/pymdp/pymdp_utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Utility functions for PyMDP simulations: JSON serialization, numpy array handling, data conversion."""
 
-import ast
 import json
 import logging
 import pickle  # nosec B403

--- a/src/gnn/execute/sandbox.py
+++ b/src/gnn/execute/sandbox.py
@@ -33,7 +33,6 @@ import os
 import shutil
 import subprocess  # nosec B404
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/gnn/export/__init__.py
+++ b/src/gnn/export/__init__.py
@@ -102,8 +102,6 @@ class Exporter:
         import tempfile
         from pathlib import Path
 
-        from .processor import _gnn_model_to_dict
-
         model_data = _gnn_model_to_dict(gnn_content)
         with tempfile.TemporaryDirectory() as tmp:
             out = export_model(model_data, Path(tmp), formats=[format_name])
@@ -121,8 +119,6 @@ class MultiFormatExporter:
         """Export to multiple formats."""
         import tempfile
         from pathlib import Path
-
-        from .processor import _gnn_model_to_dict
 
         model_data = _gnn_model_to_dict(gnn_content)
         with tempfile.TemporaryDirectory() as tmp:

--- a/src/gnn/export/core.py
+++ b/src/gnn/export/core.py
@@ -5,7 +5,7 @@ Public functions: export_gnn_files
 
 import logging
 from pathlib import Path
-from typing import Any, Tuple, cast
+from typing import Any
 
 from gnn.pipeline import get_output_dir_for_script
 from gnn.utils import log_step_error, log_step_start, log_step_success, log_step_warning

--- a/src/gnn/export/format_exporters.py
+++ b/src/gnn/export/format_exporters.py
@@ -7,8 +7,6 @@ formats, including structured data (JSON, XML), graph formats (GEXF, GraphML),
 and text-based representations (Summary, DSL).
 """
 
-import ast
-
 # Imports for specific exporters
 import json
 import logging

--- a/src/gnn/export/processor.py
+++ b/src/gnn/export/processor.py
@@ -12,8 +12,6 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-from defusedxml import ElementTree as ET
-
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 

--- a/src/gnn/gui/mcp.py
+++ b/src/gnn/gui/mcp.py
@@ -5,7 +5,6 @@ This module exposes GUI processing tools via MCP.
 """
 
 import logging
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/gnn/intelligent_analysis/mcp.py
+++ b/src/gnn/intelligent_analysis/mcp.py
@@ -5,7 +5,6 @@ This module exposes intelligent analysis processing tools via MCP.
 """
 
 import logging
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/gnn/mcp/server_stdio.py
+++ b/src/gnn/mcp/server_stdio.py
@@ -21,7 +21,7 @@ import queue
 import sys
 import threading
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/src/gnn/ml_integration/mcp.py
+++ b/src/gnn/ml_integration/mcp.py
@@ -5,7 +5,6 @@ This module exposes ML integration processing tools via MCP.
 """
 
 import logging
-from pathlib import Path
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)

--- a/src/gnn/ontology/mcp.py
+++ b/src/gnn/ontology/mcp.py
@@ -6,7 +6,6 @@ annotation extraction, and ontology report generation through MCP.
 """
 
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, Union
 
 logger = logging.getLogger(__name__)

--- a/src/gnn/parsers/schema_parser.py
+++ b/src/gnn/parsers/schema_parser.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ET  # nosec B405
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from .common import (
     BaseGNNParser,

--- a/src/gnn/parsers/xml_parser.py
+++ b/src/gnn/parsers/xml_parser.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ET  # nosec B405
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from .common import (
     BaseGNNParser,

--- a/src/gnn/pipeline/durable_streams.py
+++ b/src/gnn/pipeline/durable_streams.py
@@ -19,9 +19,7 @@ Public surface:
 """
 
 import hashlib
-import os
 import re
-import tempfile
 from enum import Enum
 from math import prod
 from pathlib import Path

--- a/src/gnn/render/activeinference_jl/activeinference_renderer.py
+++ b/src/gnn/render/activeinference_jl/activeinference_renderer.py
@@ -19,7 +19,6 @@ from gnn.render.multi_agent_common import (
     detect_agent_groups,
     detect_env_conditioned,
     detect_env_coupling,
-    has_env_conditioned_action_selection,
     has_native_multi_agent_structure,
 )
 from gnn.render.pomdp_contract import build_canonical_pomdp_spec

--- a/src/gnn/render/processor.py
+++ b/src/gnn/render/processor.py
@@ -13,7 +13,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import sys
 import tempfile
 import uuid

--- a/src/gnn/render/render.py
+++ b/src/gnn/render/render.py
@@ -9,7 +9,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/src/gnn/report/__init__.py
+++ b/src/gnn/report/__init__.py
@@ -20,7 +20,7 @@ FEATURES: dict[str, Any] = {
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from gnn.utils.pipeline_template import (
     log_step_error,
@@ -126,7 +126,6 @@ def process_report(
         True if processing succeeded, False otherwise
     """
     import json
-    from pathlib import Path
 
     if logger is None:
         logger = logging.getLogger(__name__)

--- a/src/gnn/sapf/mcp.py
+++ b/src/gnn/sapf/mcp.py
@@ -168,7 +168,7 @@ def check_audio_backends_mcp() -> Dict[str, Any]:
             "description": "Csound synthesis engine",
         }
         try:
-            import sounddevice  # type: ignore
+            import sounddevice  # type: ignore[import-not-found]  # noqa: F401 — availability probe; binding intentionally unused
 
             backends["sounddevice"] = {
                 "available": True,

--- a/src/gnn/schema/parser.py
+++ b/src/gnn/schema/parser.py
@@ -10,7 +10,6 @@ Provides:
   - validate_matrix_dimensions(): cross-checks parameterization vs declarations
 """
 
-import ast
 import logging
 import re
 from collections.abc import Sequence

--- a/src/gnn/schema_validator/validator.py
+++ b/src/gnn/schema_validator/validator.py
@@ -16,13 +16,12 @@ Enhanced Features:
 - Enhanced error reporting and suggestions
 """
 
-import json
 import logging
 import re
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 from gnn.types import (
     GNNFormat,

--- a/src/gnn/testing/round_trip_report.py
+++ b/src/gnn/testing/round_trip_report.py
@@ -11,7 +11,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from .round_trip_results import ComprehensiveTestReport
 

--- a/src/gnn/testing/test_round_trip.py
+++ b/src/gnn/testing/test_round_trip.py
@@ -54,7 +54,6 @@ from .round_trip_availability import (
     LeanSerializer,
     ParsedGNN,
     ParseResult,
-    Path,
     PKLSerializer,
     ProtobufSerializer,
     PythonSerializer,
@@ -66,9 +65,7 @@ from .round_trip_availability import (
     YAMLSerializer,
     ZNotationSerializer,
     current_file_dir,
-    os,
     src_path,
-    sys,
     validate_cross_format_consistency,
 )
 from .round_trip_comparison import RoundTripComparisonMixin
@@ -82,7 +79,6 @@ from .round_trip_config import (
 )
 from .round_trip_markdown_parser import (
     _DirectMarkdownParser,
-    logger,
 )
 from .round_trip_report import RoundTripReportMixin
 from .round_trip_results import (

--- a/src/gnn/utils/system_utils.py
+++ b/src/gnn/utils/system_utils.py
@@ -18,7 +18,7 @@ try:
 except (ImportError, RecursionError, RuntimeError):
     PSUTIL_AVAILABLE = False
 
-from typing import Any, Dict
+from typing import Dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/gnn/visualization/analysis/combined_analysis.py
+++ b/src/gnn/visualization/analysis/combined_analysis.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List
 
 import numpy as np
 

--- a/src/gnn/visualization/ontology/visualizer.py
+++ b/src/gnn/visualization/ontology/visualizer.py
@@ -13,7 +13,7 @@ import matplotlib
 matplotlib.use("Agg")  # Use non-interactive backend for server environments
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 

--- a/src/gnn/visualization/parse/markdown.py
+++ b/src/gnn/visualization/parse/markdown.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import logging
 from typing import Any, Dict, List
 

--- a/src/gnn/visualization/processor.py
+++ b/src/gnn/visualization/processor.py
@@ -10,7 +10,7 @@ from typing import Any
 # Imported after ``.core.process``: core.process itself pulls in
 # analysis.combined_analysis during package init, so by this line the
 # analysis package is fully loaded (import-order-sensitive cycle).
-from .analysis import (
+from .analysis import (  # noqa: F401 — re-export consumed by visualization/__init__
     generate_combined_analysis,
     generate_combined_visualizations,
 )


### PR DESCRIPTION
## What

TO-DO.md 'Smaller scoped cleanups' audit item: the global `F401`/`F811` entries in pyproject's ruff ignore list masked unused-import and redefinition findings across all 622 files. Replaced with targeted exemptions + dead-import removal. `ruff --select F401,F811` findings: **236 → 0**.

- **Per-file-ignores (F401) for nine genuine re-export surfaces**: the six MAJ-04 facades (`analysis/visualizations.py`, `analysis/analyzer.py`, `render/jax/jax_renderer.py`, `render/discopy/translator.py`, `integration/meta_analysis/visualizer.py`, `testing/test_round_trip.py`), `testing/round_trip_availability.py`, `integration/meta_analysis/visualizer_style.py`, and `execute/processor.py` (the 3.3.0 execute-split facade — its re-export block is load-bearing for tests/execute). Each documented in-line.
- **Per-file-ignores (F401) for `src/gnn/parsers/*`**: guarded optional-backend probes — the binding is intentionally unused; usage is gated on the probe flag.
- **66 dead imports removed**: 57 auto-fixed across 38 src/gnn modules, 10 in `scripts/*` (the main gate covers `src/gnn scripts`; narrowing surfaced them — scope addition, auto-fix only), and 9 auto-fixable F811 re-imports.
- **Hand fixes**: `analysis/activeinference_jl/analyzer.py` narrows its `viz_base` probe import to the names it uses; `sapf/mcp.py` keeps the sounddevice availability probe with `noqa` + restored `type: ignore`; `visualization/processor.py`'s import-order-sensitive re-export gains an explicit F401 noqa (cycle comment preserved); `testing/test_round_trip.py` drops `Path`/`os`/`sys`/`logger` from re-export blocks that shadowed its own stdlib imports.

## Consumer-safety audit

Every removed (file, name) pair was checked with an AST-resolved scan of all `from <module> import ...` statements across `src/gnn`, `tests`, and `scripts` — no hidden consumers outside `execute/processor.py` (exempted, restored). Backed by the full suite.

## Verification

- `ruff check src/gnn scripts`: **0 violations** under the narrowed config
- `ruff --select F401,F811 src/gnn`: **0 findings**; `ruff format --check`: clean
- `mypy src/gnn`: **0 errors** (622 files)
- Full suite (command of record): **4285 passed / 0 failed / 19 skipped**
- MAJ-04 guard metrics unchanged: `oversized_module_lines` 0, import-path stability probes all OK

## Benchmark

New session metric `ruff_policy_findings`: **236 → 0** (-100%).