### PR TITLE
docs(pipeline): point pipeline_validation See-also at the canonical runtime validator

### DIFF
--- a/src/gnn/pipeline/pipeline_validation.py
+++ b/src/gnn/pipeline/pipeline_validation.py
@@ -8,7 +8,7 @@ Does NOT run the pipeline or check runtime behavior.
 
 See also:
 - utils/pipeline_validator.py: Pre-execution prerequisite checker (checks step outputs exist)
-- pipeline/pipeline_validator.py: Runtime integration tester (runs pipeline via subprocess)
+- pipeline/pipeline_runtime_validator.py: Runtime integration tester (runs pipeline via subprocess)
 
 Usage:
     python pipeline_validation.py [--fix-issues]


### PR DESCRIPTION
One-line companion to #49: `pipeline_validation.py`'s See-also still described `pipeline/pipeline_validator.py` (now the DeprecationWarning compat module) as the runtime integration tester. Re-pointed to `pipeline/pipeline_runtime_validator.py`. Gates: terminology / path-reference exit 0, ruff clean, harness exit 0.