### PR TITLE
docs(ledger): ml-ai/torch extras parity resolved - 12 env-skipped tests verified green

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -80,10 +80,18 @@ are pinned.
   `.github/workflows/local-gates.yml` (2026-09-07; `skills-health` also
   needed a repo-root sys.path bootstrap). `just gridworld` remains
   unwired deliberately - the committed `output/` tree currently fails
-  its contract and regeneration needs the Julia toolchains. Still open:
-  the `ml-ai`/`torch` extras would unlock 12 environment-skipped tests
-  (11 sklearn, 1 torch); `test-cov` locally ignores the Ollama tests
-  while the CI coverage run does not.
+  its contract and regeneration needs the Julia toolchains.
+  ml-ai/torch extras parity: RESOLVED 2026-09-08 - verified
+  `uv sync --extra dev --extra ml-ai --extra torch --frozen` resolves from
+  the lock and un-skips the 12 environment-skipped tests (11 sklearn
+  inference tests, 1 torch continuous-render test); all 22 tests in the two
+  affected files pass with the extras present (no latent failures behind the
+  skip). The local test-cov command should therefore run with
+  `--extra ml-ai --extra torch` appended. The Ollama-ignore half of this
+  item stays open-by-design: no local Ollama daemon exists, so
+  `test-cov`'s `--ignore=tests/llm/test_llm_ollama*.py` remains correct
+  locally while the CI coverage run exercises those tests where they
+  degrade gracefully without a daemon.
 - Dependency floors: RAISED 2026-09-07 for numpy (>=2.0), pandas
   (>=2.0), openai (>=2.0), pytest (>=8.0), mypy (>=1.0) - the lock
   resolved identically (only requires-dist metadata moved; zero package


### PR DESCRIPTION
Closes the actionable half of the Local/CI parity item in TO-DO.md's Smaller scoped cleanups.

## What was verified (2026-09-08)

- `uv sync --extra dev --extra ml-ai --extra torch --frozen` resolves entirely from the lock (no pins changed) and un-skips the **12 environment-skipped tests** (11 sklearn inference tests in `tests/ml_integration/test_ml_integration_inference.py`, 1 torch continuous-render test in `tests/render/test_continuous_renderers.py`).
- All **22 tests** across the two affected files pass with the extras present — no latent failures were hiding behind the environment skips.
- Local `test-cov` should therefore append `--extra ml-ai --extra torch`.

## Deliberately left open

The Ollama-ignore half stays open-by-design: no local Ollama daemon exists, so `test-cov`'s `--ignore=tests/llm/test_llm_ollama*.py` remains correct locally; the CI coverage run exercises those tests where they degrade gracefully without a daemon.

Docs-only; no code changes.