### PR TITLE
ci(coverage): align CI coverage selection with local test-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
             --tb=short \
             -q \
             -n auto --dist worksteal \
+            --ignore=tests/llm/test_llm_ollama.py \
+            --ignore=tests/llm/test_llm_ollama_integration.py \
             --cov=gnn --cov-report=term-missing --cov-report=json:junit/coverage-${{ matrix.python-version }}.json \
             --junitxml=junit/pytest-${{ matrix.python-version }}.xml
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -82,8 +82,11 @@ are pinned.
   unwired deliberately - the committed `output/` tree currently fails
   its contract and regeneration needs the Julia toolchains. Still open:
   the `ml-ai`/`torch` extras would unlock 12 environment-skipped tests
-  (11 sklearn, 1 torch); `test-cov` locally ignores the Ollama tests
-  while the CI coverage run does not.
+  (11 sklearn, 1 torch); `test-cov`/CI coverage Ollama-ignore parity:
+  RESOLVED 2026-09-08 - the CI coverage step now carries the same two
+  Ollama `--ignore` flags as `just test-cov`, and `just test-cov` adopts
+  CI's `-m "not pipeline and not mcp"` selection (4326 tests collected on
+  both sides; was 4352 in CI).
 - Dependency floors: RAISED 2026-09-07 for numpy (>=2.0), pandas
   (>=2.0), openai (>=2.0), pytest (>=8.0), mypy (>=1.0) - the lock
   resolved identically (only requires-dist metadata moved; zero package

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ test-mod MODULE:
 
 # Run tests with coverage report
 test-cov:
-    uv run pytest tests/ --cov=gnn --cov-report=term-missing \
+    uv run pytest tests/ -m "not pipeline and not mcp" --cov=gnn --cov-report=term-missing \
         --ignore=tests/llm/test_llm_ollama.py \
         --ignore=tests/llm/test_llm_ollama_integration.py
 


### PR DESCRIPTION
Resolves the registered Local/CI-parity residue in TO-DO.md: the CI coverage run collected `tests/llm/test_llm_ollama*.py` while `just test-cov` ignored them (and CI deselected `pipeline`/`mcp`-marked tests that local coverage still ran) — so the two invocations measured different test sets.

Both directions aligned: CI coverage step gains the two `--ignore` flags; `just test-cov` adopts CI's `-m "not pipeline and not mcp"` selection. Selection verified locally (4326 vs 4352 collected; delta = the 26 Ollama tests). Note: `fail_under = 50` in pyproject will arbitrate the measured-set change in CI before merge.