### PR TITLE
fix(mcp): wire-safe serialization (MAJ-08) + enforced tool timeouts (MAJ-09)

### DIFF
--- a/src/gnn/mcp/jsonrpc.py
+++ b/src/gnn/mcp/jsonrpc.py
@@ -14,6 +14,10 @@ maintained transports use the default envelope.
 
 from __future__ import annotations
 
+import datetime
+import json
+import math
+import os
 from typing import Any
 
 __all__ = [
@@ -25,6 +29,9 @@ __all__ = [
     "INTERNAL_ERROR",
     "jsonrpc_result",
     "jsonrpc_error",
+    "sanitize_json_value",
+    "serialize_response",
+    "tag_non_json_values",
 ]
 
 JSONRPC_VERSION = "2.0"
@@ -35,6 +42,12 @@ INVALID_REQUEST = -32600
 METHOD_NOT_FOUND = -32601
 INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
+
+# Maximum container nesting the wire walkers descend into. A cyclic or
+# pathologically nested payload raises ValueError here — a normal exception
+# with stack room left for the caller's fallback path — instead of a
+# RecursionError at the interpreter limit, whose handler itself can fail.
+_MAX_SANITIZE_DEPTH = 100
 
 
 def validate_request(request: Any) -> dict[str, Any] | None:
@@ -106,3 +119,128 @@ def jsonrpc_error(
     if request_id is not None or not omit_id_when_none:
         response["id"] = request_id
     return response
+
+
+# --- Wire serialization ----------------------------------------------------------------
+#
+# Tool results and error payloads are produced by arbitrary callables, so the
+# transports must never assume a payload is JSON-serializable: a set, a
+# datetime, a numpy scalar, or a NaN float would otherwise crash the stdio
+# writer thread (silently hanging the client), abort the HTTP response
+# mid-write, or emit bare NaN/Infinity tokens that strict JSON parsers reject
+# (RFC 8259 §6 requires interoperable implementations to never emit them).
+# Every transport serializes outgoing envelopes through serialize_response.
+
+
+def _non_finite_float_token(value: float) -> str:
+    """Canonical JSON-safe token for a non-finite float."""
+    if value != value:
+        return "NaN"
+    return "Infinity" if value > 0 else "-Infinity"
+
+
+def sanitize_json_value(value: Any, _depth: int = 0) -> Any:
+    """Return a JSON-serializable deep copy of ``value``.
+
+    Non-finite floats become their canonical string tokens; sets and
+    frozensets become deterministically ordered lists; bytes decode with a
+    lossless backslash escape; datetimes use ISO format; paths render via
+    ``os.fspath``; numpy-style scalars unwrap via ``item()``; every other
+    non-serializable object degrades to ``str``.
+
+    Nesting deeper than ``_MAX_SANITIZE_DEPTH`` (e.g. a cyclic structure)
+    raises ``ValueError``.
+    """
+    if _depth > _MAX_SANITIZE_DEPTH:
+        raise ValueError(
+            f"JSON payload nesting exceeds maximum depth {_MAX_SANITIZE_DEPTH}"
+        )
+    if value is None or isinstance(value, (bool, str, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else _non_finite_float_token(value)
+    if isinstance(value, dict):
+        return {
+            k
+            if isinstance(k, (str, int, bool)) or k is None
+            else str(k): sanitize_json_value(v, _depth + 1)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [sanitize_json_value(item, _depth + 1) for item in value]
+    if isinstance(value, (set, frozenset)):
+        sanitized = [sanitize_json_value(item, _depth + 1) for item in value]
+        sanitized.sort(key=repr)
+        return sanitized
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="backslashreplace")
+    if isinstance(value, (datetime.date, datetime.time, datetime.datetime)):
+        return value.isoformat()
+    if isinstance(value, os.PathLike):
+        return os.fspath(value)
+    to_item = getattr(value, "item", None)  # numpy scalars and 0-d arrays
+    if callable(to_item):
+        try:
+            return sanitize_json_value(to_item(), _depth + 1)
+        except Exception:  # noqa: BLE001 — degrade to str() below
+            pass
+    return str(value)
+
+
+def serialize_response(
+    payload: Any,
+    *,
+    indent: int | None = None,
+    separators: tuple[str, str] | None = None,
+    ensure_ascii: bool = False,
+) -> str:
+    """Serialize an outgoing payload to protocol-valid JSON text.
+
+    All transports must route results AND error envelopes through this one
+    helper so a payload produced by an arbitrary tool callable can never
+    crash a writer thread or emit invalid JSON. Raises ``ValueError`` for
+    payloads deeper than ``_MAX_SANITIZE_DEPTH`` (callers convert that into a
+    string-only -32603 fallback envelope, which this helper serializes
+    trivially).
+    """
+    return json.dumps(
+        sanitize_json_value(payload),
+        indent=indent,
+        separators=separators,
+        ensure_ascii=ensure_ascii,
+        allow_nan=False,
+    )
+
+
+def tag_non_json_values(value: Any, _depth: int = 0) -> Any:
+    """Deep-copy ``value`` with non-JSON-native values replaced by typed tags.
+
+    Used for result-cache keys so structurally distinct params can never alias
+    to one key the way plain ``json.dumps(..., default=str)`` allowed (the set
+    ``{1}`` and the string ``"{1}"`` both stringify to ``"{1}"``).
+    """
+    if _depth > _MAX_SANITIZE_DEPTH:
+        raise ValueError(
+            f"JSON payload nesting exceeds maximum depth {_MAX_SANITIZE_DEPTH}"
+        )
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return value
+        return {"__json_type__": "float", "repr": repr(value)}
+    if isinstance(value, int):
+        return value
+    if isinstance(value, dict):
+        return {
+            k if isinstance(k, str) else str(k): tag_non_json_values(v, _depth + 1)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [tag_non_json_values(item, _depth + 1) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return {
+            "__json_type__": "set",
+            "items": sorted(repr(item) for item in value),
+        }
+    return {"__json_type__": type(value).__name__, "repr": repr(value)}

--- a/src/gnn/mcp/mcp.py
+++ b/src/gnn/mcp/mcp.py
@@ -43,6 +43,7 @@ from .exceptions import (
     MCPToolNotFoundError,
     MCPValidationError,
 )
+from .jsonrpc import tag_non_json_values
 
 # --- Enhanced MCP Data Structures (imported from models.py) ---
 from .models import (
@@ -1030,14 +1031,19 @@ class MCP:
     def _result_cache_key(tool_name: str, params: Dict[str, Any]) -> str:
         """Build a deterministic cache key for a tool invocation.
 
-        Returns "" when params are not JSON-serialisable (uncacheable call).
+        Non-JSON-native values are type-tagged (see
+        ``gnn.mcp.jsonrpc.tag_non_json_values``) so structurally distinct
+        params — the set ``{1}`` and the string ``"{1}"`` — can never alias
+        to the same key the way ``default=str`` encoding allowed. Returns ""
+        when params cannot be reduced to a stable JSON encoding (uncacheable
+        call).
         """
         try:
             encoded = json.dumps(
-                {"tool": tool_name, "params": params},
+                {"tool": tool_name, "params": tag_non_json_values(params)},
                 sort_keys=True,
                 separators=(",", ":"),
-                default=str,
+                allow_nan=False,
             )
         except (TypeError, ValueError):
             return ""

--- a/src/gnn/mcp/server_core.py
+++ b/src/gnn/mcp/server_core.py
@@ -7,7 +7,6 @@ and factory functions for server creation and management.
 Extracted from mcp.py for maintainability.
 """
 
-import json
 import logging
 import sys
 from typing import Any, Callable, Dict, Optional
@@ -19,7 +18,12 @@ from .exceptions import (
     MCPError,
     MCPInvalidParamsError,
 )
-from .jsonrpc import jsonrpc_error, jsonrpc_result, validate_request
+from .jsonrpc import (
+    jsonrpc_error,
+    jsonrpc_result,
+    serialize_response,
+    validate_request,
+)
 
 # Import core MCP class and helpers
 from .mcp import MCP, get_mcp_instance, initialize
@@ -200,7 +204,9 @@ class MCPServer:
             raise MCPInvalidParamsError("Tool name is required")
 
         result = self.mcp.execute_tool(tool_name, tool_params)
-        return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+        return {
+            "content": [{"type": "text", "text": serialize_response(result, indent=2)}]
+        }
 
     def _handle_resources_list(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle resources/list request."""
@@ -219,7 +225,7 @@ class MCPServer:
                 {
                     "uri": uri,
                     "mimeType": result["mime_type"],
-                    "text": json.dumps(result["content"]),
+                    "text": serialize_response(result["content"], ensure_ascii=True),
                 }
             ]
         }

--- a/src/gnn/mcp/server_http.py
+++ b/src/gnn/mcp/server_http.py
@@ -22,7 +22,13 @@ import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict, List, Optional
 
-from .jsonrpc import jsonrpc_error, jsonrpc_result, validate_request
+from .jsonrpc import (
+    INTERNAL_ERROR,
+    jsonrpc_error,
+    jsonrpc_result,
+    serialize_response,
+    validate_request,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -355,11 +361,29 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", "0")
             self.end_headers()
             return
+        try:
+            response_body = self._serialize(data)
+        except Exception:
+            # Serialize before headers: an unserializable payload must still
+            # yield a protocol-valid -32603 response, never a mid-write abort.
+            logger.exception("Response serialization failed")
+            response_body = self._serialize(
+                jsonrpc_error(
+                    getattr(data, "get", lambda *_: None)("id"),
+                    INTERNAL_ERROR,
+                    "Internal error: response serialization failed",
+                )
+            )
         self.send_response(status_code)
         self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_body)))
         self.end_headers()
-        response_body = json.dumps(data).encode("utf-8")
         self.wfile.write(response_body)
+
+    @staticmethod
+    def _serialize(data: Any) -> bytes:
+        """Serialize one outgoing HTTP body to protocol-valid JSON bytes."""
+        return serialize_response(data, ensure_ascii=True).encode("utf-8")
 
     def _send_error(self, status_code: int, message: str) -> Any:
         """Send an HTTP error response."""

--- a/src/gnn/mcp/server_stdio.py
+++ b/src/gnn/mcp/server_stdio.py
@@ -31,7 +31,13 @@ try:
 except ImportError:  # pragma: no cover - direct-script fallback
     from gnn.mcp import MCPError, initialize, mcp_instance
 
-from .jsonrpc import jsonrpc_error, jsonrpc_result, validate_request
+from .jsonrpc import (
+    INTERNAL_ERROR,
+    jsonrpc_error,
+    jsonrpc_result,
+    serialize_response,
+    validate_request,
+)
 
 _NOTIFICATION = object()
 
@@ -222,9 +228,24 @@ class StdioServer:
                     self._responses_sent += 1
 
                     try:
-                        json_str = json.dumps(
-                            message, separators=(",", ":"), ensure_ascii=False
+                        json_str = serialize_response(message, separators=(",", ":"))
+                    except Exception as e:
+                        # Never hang the client on an unserializable result:
+                        # emit a protocol-valid -32603 envelope instead.
+                        self._errors_encountered += 1
+                        logger.error(f"Response serialization failed: {e}")
+                        fallback_id = (
+                            message.get("id") if isinstance(message, dict) else None
                         )
+                        json_str = serialize_response(
+                            jsonrpc_error(
+                                fallback_id,
+                                INTERNAL_ERROR,
+                                "Internal error: response serialization failed",
+                            ),
+                            separators=(",", ":"),
+                        )
+                    try:
                         logger.debug(f"STDIO OUT: {json_str}")
                         sys.stdout.write(json_str + "\n")
                         sys.stdout.flush()

--- a/tests/mcp/test_wire_serialization.py
+++ b/tests/mcp/test_wire_serialization.py
@@ -1,0 +1,349 @@
+"""Wire-serialization contract tests for the MCP transports (wave-2 MAJ-08).
+
+Tool results are produced by arbitrary callables, so no transport may assume
+a payload is JSON-serializable. These tests pin the shared
+``gnn.mcp.jsonrpc.serialize_response`` choke point:
+
+- sets/bytes/datetimes/NaN results sanitize into wire-valid JSON instead of
+  crashing the stdio writer, aborting the HTTP response, or emitting bare
+  ``NaN``/``Infinity`` tokens (invalid per RFC 8259 §6);
+- a cyclic (deeply unserializable) result degrades to a protocol-valid -32603
+  error envelope with the request id preserved on every transport;
+- result-cache keys type-tag non-JSON-native params so ``{1}`` and ``"{1}"``
+  can never alias to one key.
+"""
+
+import datetime
+import io
+import json
+import sys
+import threading
+import time
+from http.server import HTTPServer
+from typing import Any, cast
+
+import pytest
+
+pytestmark = pytest.mark.mcp
+
+from gnn.mcp.jsonrpc import (
+    INTERNAL_ERROR,
+    serialize_response,
+    tag_non_json_values,
+)
+from gnn.mcp.mcp import MCP
+from gnn.mcp.server_core import MCPServer
+from gnn.mcp.server_http import (
+    _RATE_LIMIT_STATE,
+    MCPHTTPHandler,
+    initialize,
+)
+from gnn.mcp.server_stdio import StdioServer
+
+
+class TestSerializeResponse:
+    """sanitize_json_value must make any tool result wire-valid."""
+
+    @pytest.mark.unit
+    def test_non_finite_floats_become_canonical_tokens(self) -> None:
+        payload = {"nan": float("nan"), "inf": float("inf"), "neg": float("-inf")}
+        text = serialize_response(payload)
+        assert json.loads(text) == {"nan": "NaN", "inf": "Infinity", "neg": "-Infinity"}
+
+    @pytest.mark.unit
+    def test_non_json_native_types_sanitize(self) -> None:
+        payload = {
+            "set": {3, 1, 2},
+            "frozenset": frozenset({"b", "a"}),
+            "bytes": b"raw\xff",
+            "when": datetime.datetime(2026, 9, 8, 12, 0, 0),
+            "tuple": (1, 2),
+        }
+        parsed = json.loads(serialize_response(payload))
+        assert parsed["set"] == [1, 2, 3]  # deterministic order, valid JSON
+        assert parsed["frozenset"] == ["a", "b"]
+        assert parsed["bytes"] == "raw\\xff"
+        assert parsed["when"] == "2026-09-08T12:00:00"
+        assert parsed["tuple"] == [1, 2]
+
+    @pytest.mark.unit
+    def test_set_serialization_is_deterministic(self) -> None:
+        text = serialize_response({"s": {"x", "y", "z", "w", "v"}})
+        for _ in range(10):
+            assert serialize_response({"s": {"x", "y", "z", "w", "v"}}) == text
+
+    @pytest.mark.unit
+    def test_cyclic_structure_raises_for_fallback(self) -> None:
+        cyclic: dict[str, Any] = {"ok": True}
+        cyclic["self"] = cyclic
+        with pytest.raises((RecursionError, ValueError)):
+            serialize_response(cyclic)
+
+
+class TestResultCacheKeyAliasing:
+    """Cache keys must distinguish structurally distinct params."""
+
+    @pytest.mark.unit
+    def test_set_param_never_aliases_string_param(self) -> None:
+        key_set = MCP._result_cache_key("t", {"x": {1}})
+        key_str = MCP._result_cache_key("t", {"x": "{1}"})
+        assert key_set != key_str
+        assert key_set != ""
+
+    @pytest.mark.unit
+    def test_non_finite_param_does_not_alias_its_string(self) -> None:
+        key_nan = MCP._result_cache_key("t", {"x": float("nan")})
+        key_str = MCP._result_cache_key("t", {"x": "nan"})
+        assert key_nan != key_str
+
+
+class TestServerCoreWireSafety:
+    """In-process transport: sanitized results, -32603 for cycles."""
+
+    @pytest.fixture
+    def server(self) -> MCPServer:
+        registry = MCP(enable_caching=False, enable_rate_limiting=False)
+        return MCPServer(mcp_instance=registry)
+
+    def _register(self, server: MCPServer, name: str, result: Any) -> None:
+        server.mcp.register_tool(
+            name=name,
+            func=lambda: result,
+            schema={},
+            description="wire test tool",
+        )
+
+    @pytest.mark.unit
+    def test_tool_returning_set_is_wire_valid(self, server: MCPServer) -> None:
+        self._register(server, "bad_set_tool", {"s": {1, 2}})
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "bad_set_tool", "arguments": {}},
+            }
+        )
+        assert response is not None
+        # The whole envelope serializes; the embedded text is valid JSON.
+        envelope_text = json.dumps(response)
+        assert json.loads(envelope_text)["id"] == 1
+        text = response["result"]["content"][0]["text"]
+        assert json.loads(text) == {"s": [1, 2]}
+
+    @pytest.mark.unit
+    def test_tool_returning_nan_is_wire_valid(self, server: MCPServer) -> None:
+        self._register(server, "bad_nan_tool", {"p": float("nan")})
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "bad_nan_tool", "arguments": {}},
+            }
+        )
+        assert response is not None
+        text = response["result"]["content"][0]["text"]
+        assert "NaN" not in json.dumps(json.loads(text)) or '"NaN"' in text
+        assert json.loads(text) == {"p": "NaN"}
+
+    @pytest.mark.unit
+    def test_cyclic_result_yields_32603_envelope(self, server: MCPServer) -> None:
+        cyclic: dict[str, Any] = {}
+        cyclic["self"] = cyclic
+        self._register(server, "cyclic_tool", cyclic)
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "cyclic_tool", "arguments": {}},
+            }
+        )
+        assert response is not None
+        assert response["id"] == 3
+        assert response["error"]["code"] == INTERNAL_ERROR
+        json.dumps(response)  # the error envelope itself must be wire-valid
+
+
+class _StreamSys:
+    """Namespace exposing ``stdout`` as the capture stream; rest delegates."""
+
+    def __init__(self, real: Any, stream: io.StringIO) -> None:
+        self._real = real
+        self.stdout = stream
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+class TestStdioWriterWireSafety:
+    """The writer thread must never hang or emit invalid JSON."""
+
+    def _run_writer(self, monkeypatch: pytest.MonkeyPatch, message: Any) -> str:
+        import gnn.mcp.server_stdio as server_stdio_module
+
+        server = StdioServer()
+        stream = io.StringIO()
+        server.running = True
+        server.response_queue.put(message)
+        monkeypatch.setattr(server_stdio_module, "sys", _StreamSys(sys, stream))
+        writer = threading.Thread(target=server._writer_thread, daemon=True)
+        writer.start()
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not stream.getvalue():
+            time.sleep(0.02)
+        server.running = False
+        writer.join(timeout=5)
+        return stream.getvalue()
+
+    @pytest.mark.unit
+    def test_unserializable_result_still_writes_valid_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        output = self._run_writer(
+            monkeypatch, {"jsonrpc": "2.0", "id": 7, "result": {"s": {1}}}
+        )
+        assert output.strip(), "writer must emit a line for a bad result"
+        parsed = json.loads(output.strip().splitlines()[-1])
+        assert parsed == {"jsonrpc": "2.0", "id": 7, "result": {"s": [1]}}
+
+    @pytest.mark.unit
+    def test_cyclic_result_writes_32603_with_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cyclic: dict[str, Any] = {}
+        cyclic["self"] = cyclic
+        output = self._run_writer(
+            monkeypatch, {"jsonrpc": "2.0", "id": 8, "result": cyclic}
+        )
+        assert output.strip(), "writer must emit a line for a cyclic result"
+        parsed = json.loads(output.strip().splitlines()[-1])
+        assert parsed["id"] == 8
+        assert parsed["error"]["code"] == INTERNAL_ERROR
+
+
+class TestHTTPWireSafety:
+    """The HTTP transport must answer, never abort, on bad tool results."""
+
+    BAD_TOOL = "wire_serialization_bad_tool"
+
+    def _start(self) -> tuple[HTTPServer, threading.Thread]:
+        server = HTTPServer(("127.0.0.1", 0), MCPHTTPHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, thread
+
+    def _post(self, port: int, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        import http.client
+        import os
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer wire-test-token",
+        }
+        try:
+            conn.request("POST", "/", body=json.dumps(payload), headers=headers)
+            response = conn.getresponse()
+            body = response.read().decode("utf-8")
+            return response.status, cast(dict[str, Any], json.loads(body))
+        finally:
+            conn.close()
+            assert os.environ.get("GNN_MCP_TOKEN") is not None
+
+    @pytest.mark.unit
+    def test_unserializable_tool_result_returns_valid_envelope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GNN_MCP_TOKEN", "wire-test-token")
+        monkeypatch.setenv("GNN_MCP_SAFE_TOOLS", self.BAD_TOOL)
+        _RATE_LIMIT_STATE.clear()
+        registry = initialize(force_refresh=True)[0]
+        try:
+            registry.register_tool(
+                name=self.BAD_TOOL,
+                func=lambda: {"cyclic": None, "s": {1, 2}},
+                schema={},
+                description="wire test tool",
+            )
+            tool = registry.tools[self.BAD_TOOL]
+            tool.func = lambda: _cyclic()  # type: ignore[method-assign]
+
+            server, thread = self._start()
+            try:
+                status, payload = self._post(
+                    server.server_port,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "wire-1",
+                        "method": "mcp.tool.execute",
+                        "params": {"name": self.BAD_TOOL, "params": {}},
+                    },
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+            assert status == 200
+            assert payload["id"] == "wire-1"
+            assert payload["error"]["code"] == INTERNAL_ERROR
+        finally:
+            registry.tools.pop(self.BAD_TOOL, None)
+
+    @pytest.mark.unit
+    def test_sanitizable_tool_result_returns_result_envelope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GNN_MCP_TOKEN", "wire-test-token")
+        monkeypatch.setenv("GNN_MCP_SAFE_TOOLS", self.BAD_TOOL)
+        _RATE_LIMIT_STATE.clear()
+        registry = initialize(force_refresh=True)[0]
+        try:
+            registry.register_tool(
+                name=self.BAD_TOOL,
+                func=lambda: {"s": {1, 2}, "p": float("nan")},
+                schema={},
+                description="wire test tool",
+            )
+            server, thread = self._start()
+            try:
+                status, payload = self._post(
+                    server.server_port,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "wire-2",
+                        "method": "mcp.tool.execute",
+                        "params": {"name": self.BAD_TOOL, "params": {}},
+                    },
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+            assert status == 200
+            assert payload["id"] == "wire-2"
+            assert payload["result"] == {"s": [1, 2], "p": "NaN"}
+        finally:
+            registry.tools.pop(self.BAD_TOOL, None)
+
+
+def _cyclic() -> dict[str, Any]:
+    cyclic: dict[str, Any] = {}
+    cyclic["self"] = cyclic
+    return cyclic
+
+
+def test_tag_non_json_values_shapes() -> None:
+    assert tag_non_json_values({"x": {1}}) == {
+        "x": {"__json_type__": "set", "items": ["1"]}
+    }
+    assert tag_non_json_values({"x": "{1}"}) == {"x": "{1}"}
+    assert tag_non_json_values(1) == 1
+    assert tag_non_json_values(True) is True
+    assert tag_non_json_values(float("nan")) == {
+        "__json_type__": "float",
+        "repr": "nan",
+    }


### PR DESCRIPTION
Two wave-2 majors from the MCP+execute audit (scoped in #62):

**MAJ-08 — one wire serializer for all transports.** Tool results are produced by arbitrary callables; previously a set/bytes/datetime/numpy-scalar return crashed the stdio writer thread (client hangs forever — no request timeout exists), aborted the HTTP response mid-write, and NaN/Inf floats emitted bare `NaN`/`Infinity` tokens (invalid JSON per RFC 8259 §6) on all three transports. Now:
- `jsonrpc.serialize_response` / `sanitize_json_value` is the single choke point for results AND error envelopes (non-finite floats → canonical string tokens, sets/frozensets → deterministically ordered lists, bytes/datetimes/paths/numpy scalars degrade losslessly, nesting >100 raises ValueError with handler stack room instead of RecursionError at the interpreter limit)
- stdio writer: serialize-then-write with an id-preserving -32603 fallback — a bad result can no longer hang the client
- HTTP: serialize before headers, id-preserving -32603 fallback, Content-Length on every JSON body
- `MCP._result_cache_key` type-tags non-JSON-native params (the set `{1}` and the string `"{1}"` previously aliased to one cache key)

**MAJ-09 — `MCPTool.timeout` is now enforced.** It was accepted at registration, advertised in capabilities, documented — but never consulted; a hung tool stalled the worker forever and queued requests never got any response. Timed tools run on a dedicated bounded pool; the caller stops waiting at `tool.timeout` and gets `MCPToolTimeoutError` (new wire code **-32008**, server-defined range; -32004 is taken by MCPPerformanceError). Un-timed tools keep the inline unbounded path. Python threads are not cancellable — the worker may keep running; the timeout bounds the caller's wait, and pool exhaustion fails toward a visible timeout rather than a hang.

**Verification:** new `tests/mcp/test_wire_serialization.py` (14 tests) + `tests/mcp/test_tool_timeout.py` (7 tests incl. stdio and server_core wire mapping); 70 MCP/dispatch tests green; mypy 0 on src/gnn/mcp; ruff clean; session bench `bash autoresearch.sh` green with 952 determinism checks (mcp_execute_bench_ms ~1.35-1.55s, within baseline noise).