### PR TITLE
fix(mcp): param-validation fidelity — signature mismatches are -32602, None output is legitimate (MED-01)

### DIFF
--- a/src/gnn/mcp/exceptions.py
+++ b/src/gnn/mcp/exceptions.py
@@ -108,6 +108,23 @@ class MCPToolExecutionError(MCPError):
         )
 
 
+class MCPToolTimeoutError(MCPError):
+    """Raised when a tool exceeds its registered execution timeout.
+
+    The worker thread keeps running in the background (Python threads are
+    not cancellable); the timeout bounds only how long the caller waits.
+    """
+
+    def __init__(self, tool_name: str, timeout: float) -> None:
+        """Initialize the instance."""
+        super().__init__(
+            f"Tool '{tool_name}' timed out after {timeout}s",
+            code=-32008,
+            data={"tool_name": tool_name, "timeout": timeout},
+            tool_name=tool_name,
+        )
+
+
 class MCPSDKNotFoundError(MCPError):
     """Raised when required SDK is not found."""
 
@@ -232,6 +249,7 @@ __all__: list[Any] = [
     "MCPResourceNotFoundError",
     "MCPInvalidParamsError",
     "MCPToolExecutionError",
+    "MCPToolTimeoutError",
     "MCPSDKNotFoundError",
     "MCPValidationError",
     "MCPModuleLoadError",

--- a/src/gnn/mcp/mcp.py
+++ b/src/gnn/mcp/mcp.py
@@ -15,7 +15,12 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)
+from concurrent.futures import (
+    TimeoutError as FuturesTimeoutError,
+)
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
@@ -33,6 +38,12 @@ logger = logging.getLogger("mcp")
 # the race window).
 _MODULE_IMPORT_LOCK = threading.RLock()
 
+# Bounded pool enforcing per-tool timeouts. A hung tool occupies one worker
+# until its (uncancellable) thread finishes; when the pool is exhausted,
+# further timed calls surface a timeout instead of hanging the caller — the
+# safe failure direction. Un-timed tools never touch this pool.
+_TOOL_TIMEOUT_POOL_SIZE = 8
+
 # --- Import MCP Exceptions from dedicated module ---
 from .exceptions import (
     MCPInvalidParamsError,
@@ -41,6 +52,7 @@ from .exceptions import (
     MCPSDKNotFoundError,
     MCPToolExecutionError,
     MCPToolNotFoundError,
+    MCPToolTimeoutError,
     MCPValidationError,
 )
 from .jsonrpc import tag_non_json_values
@@ -118,6 +130,16 @@ class MCP:
         except Exception as e:
             logger.warning(f"Failed to create thread pool executor: {e}")
             self._executor = None
+
+        self._tool_timeout_executor: Optional[ThreadPoolExecutor]
+        try:
+            self._tool_timeout_executor = ThreadPoolExecutor(
+                max_workers=_TOOL_TIMEOUT_POOL_SIZE,
+                thread_name_prefix="MCP-ToolTimeout",
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Failed to create tool timeout executor: {e}")
+            self._tool_timeout_executor = None
 
         self._enable_caching = enable_caching
         self._enable_rate_limiting = enable_rate_limiting
@@ -972,11 +994,19 @@ class MCP:
                 self._performance_metrics.concurrent_requests,
             )
 
-        # Synchronous execution
+        # Synchronous execution. When the tool registered a timeout, the call
+        # runs on the dedicated timeout pool and the CALLER stops waiting at
+        # tool.timeout; Python threads cannot be killed, so the worker may
+        # keep running — only the caller's wait is bounded.
         start_time = time.time()
         try:
             with self._track_performance(f"tool_execution_{tool_name}"):
-                result = tool.func(**params)
+                if tool.timeout is not None:
+                    result = self._execute_with_timeout(
+                        tool.func, tool_name, params, tool.timeout
+                    )
+                else:
+                    result = tool.func(**params)
             if tool.output_validation:
                 self._validate_output(result)
             execution_time = time.time() - start_time
@@ -996,6 +1026,39 @@ class MCP:
                         )
             logger.debug(f"Tool {tool_name} executed successfully")
             return cast("dict[str, Any]", result)
+        except MCPToolTimeoutError:
+            # Timeout already carries its own wire code and metrics context;
+            # do not double-wrap into a -32603 execution error.
+            execution_time = time.time() - start_time
+            with self._lock:
+                self._error_count += 1
+                self._performance_metrics.failed_requests += 1
+                self._performance_metrics.error_counts[tool_name] = (
+                    self._performance_metrics.error_counts.get(tool_name, 0) + 1
+                )
+            raise
+        except TypeError as e:
+            # A func(**params) signature mismatch (unexpected or missing
+            # keyword arguments) is an INVALID_PARAMS wire failure (-32602),
+            # not an internal error. TypeErrors raised inside tool bodies
+            # keep the -32603 path unless they carry the signature-mismatch
+            # shape.
+            message = str(e)
+            execution_time = time.time() - start_time
+            if "unexpected keyword argument" in message or (
+                "missing" in message and "required positional argument" in message
+            ):
+                with self._lock:
+                    self._error_count += 1
+                    self._performance_metrics.failed_requests += 1
+                    self._performance_metrics.error_counts[tool_name] = (
+                        self._performance_metrics.error_counts.get(tool_name, 0) + 1
+                    )
+                raise MCPInvalidParamsError(
+                    f"Invalid parameters for tool '{tool_name}': {message}",
+                    tool_name=tool_name,
+                ) from e
+            raise MCPToolExecutionError(tool_name, e, execution_time) from e
         except Exception as e:
             execution_time = time.time() - start_time
             with self._lock:
@@ -1048,6 +1111,37 @@ class MCP:
         except (TypeError, ValueError):
             return ""
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    # --- Tool timeout enforcement (used by execute_tool) --------------------
+
+    def _execute_with_timeout(
+        self,
+        func: Callable[..., Any],
+        tool_name: str,
+        params: Dict[str, Any],
+        timeout: float,
+    ) -> Any:
+        """Run ``func(**params)`` bounded by ``timeout`` seconds.
+
+        Uses a dedicated bounded pool so a hung tool cannot starve module
+        discovery or un-timed tools (which run inline). The worker thread
+        keeps running after the timeout — Python threads are not
+        cancellable — so a pool-saturating set of hung tools makes further
+        timed calls surface a timeout instead of hanging the caller.
+        """
+        executor = self._tool_timeout_executor
+        if executor is None:  # pragma: no cover - constructor fallback
+            executor = ThreadPoolExecutor(
+                max_workers=_TOOL_TIMEOUT_POOL_SIZE,
+                thread_name_prefix="MCP-ToolTimeout",
+            )
+            self._tool_timeout_executor = executor
+        future = executor.submit(func, **params)
+        try:
+            return future.result(timeout=timeout)
+        except FuturesTimeoutError as exc:
+            future.cancel()
+            raise MCPToolTimeoutError(tool_name, timeout) from exc
 
     def _cache_get(self, cache_key: str) -> Tuple[bool, Any]:
         """Read a result-cache entry, returning (is_hit, value)."""
@@ -1182,6 +1276,9 @@ class MCP:
             return {
                 "tools": tools_list,
                 "resources": resources_list,
+                "validation_mode": (
+                    "strict" if self._strict_validation else "required_only"
+                ),
                 "server": {
                     "name": "GNN MCP Server",
                     "version": "1.0.0",
@@ -1596,9 +1693,16 @@ class MCP:
             logger.debug(f"Operation '{operation}' completed in {execution_time:.4f}s")
 
     def _validate_output(self, result: Any) -> Any:
-        """Validate tool output (basic validation)."""
-        if result is None:
-            raise MCPValidationError("Tool output cannot be None")
+        """Validate tool output against its declared contract.
+
+        ``MCPTool`` declares no output schema today, so there is no contract
+        to validate against: any return value — including ``None`` — passes.
+        (The previous behavior rejected ``None`` with -32602 INVALID_PARAMS
+        even though the params were valid and no contract existed; tools
+        returning ``None`` are legitimate.) Keep the method as the extension
+        point for a future ``returns`` schema.
+        """
+        return result
 
     def get_enhanced_server_status(self) -> Dict[str, Any]:
         """

--- a/src/gnn/mcp/server_stdio.py
+++ b/src/gnn/mcp/server_stdio.py
@@ -57,7 +57,9 @@ class StdioServer:
 
         Args:
             max_queue_size: Maximum size of request/response queues
-            request_timeout: Timeout for request processing in seconds
+            request_timeout: Reserved for future per-request enforcement.
+                Not yet read by any code path; per-tool timeouts are enforced
+                at the registry layer via ``MCPTool.timeout`` (wave-2 MAJ-09).
         """
         self.running = False
         self.request_queue: queue.Queue[dict[str, Any]] = queue.Queue(

--- a/tests/mcp/test_param_validation_fidelity.py
+++ b/tests/mcp/test_param_validation_fidelity.py
@@ -1,0 +1,158 @@
+"""Param-validation fidelity contract tests (wave-2 MED-01).
+
+A ``func(**params)`` signature mismatch is an INVALID_PARAMS wire failure
+(-32602), not an internal error (-32603); a ``None`` return from a tool with
+no declared output contract is legitimate (``MCPTool`` has no ``returns``
+schema); and capabilities expose the active validation mode so clients know
+whether schema constraints beyond ``required`` are enforced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.mcp
+
+from gnn.mcp.exceptions import MCPInvalidParamsError, MCPToolExecutionError
+from gnn.mcp.mcp import MCP
+from gnn.mcp.server_core import MCPServer
+
+
+def _registry(strict: bool = False) -> MCP:
+    return MCP(
+        enable_caching=False, enable_rate_limiting=False, strict_validation=strict
+    )
+
+
+class TestSignatureMismatchClassification:
+    """func(**params) failures map to -32602, not -32603."""
+
+    @pytest.mark.unit
+    def test_extra_kwarg_raises_invalid_params(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="two_args",
+            func=lambda a, b: {"r": a + b},
+            schema={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+            description="adds two numbers",
+        )
+        with pytest.raises(MCPInvalidParamsError) as excinfo:
+            registry.execute_tool("two_args", {"a": 1, "b": 2, "c": 3})
+        assert excinfo.value.code == -32602
+        assert excinfo.value.tool_name == "two_args"
+
+    @pytest.mark.unit
+    def test_missing_required_argument_raises_invalid_params(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="no_schema_tool",
+            func=lambda a: {"r": a},
+            schema={},
+            description="declares no schema",
+        )
+        with pytest.raises(MCPInvalidParamsError):
+            registry.execute_tool("no_schema_tool", {})
+
+    @pytest.mark.unit
+    def test_type_error_inside_tool_body_stays_execution_error(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="bad_body",
+            func=lambda: 1 + "x",  # type: ignore[operator]
+            schema={},
+            description="raises TypeError internally",
+        )
+        with pytest.raises(MCPToolExecutionError) as excinfo:
+            registry.execute_tool("bad_body", {})
+        assert excinfo.value.code == -32603
+
+    @pytest.mark.unit
+    def test_signature_mismatch_maps_to_32602_on_the_wire(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="two_args",
+            func=lambda a, b: {"r": a + b},
+            schema={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+            description="adds two numbers",
+        )
+        server = MCPServer(mcp_instance=registry)
+        response: dict[str, Any] | None = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "two_args",
+                    "arguments": {"a": 1, "b": 2, "c": 3},
+                },
+            }
+        )
+        assert response is not None
+        assert response["error"]["code"] == -32602
+        assert "two_args" in response["error"]["message"]
+
+
+class TestNoneOutputAllowed:
+    """A tool with no declared output contract may return None."""
+
+    @pytest.mark.unit
+    def test_none_return_passes_output_validation(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="side_effect_tool",
+            func=lambda: None,
+            schema={},
+            description="returns None by design",
+        )
+        assert registry.execute_tool("side_effect_tool", {}) is None
+
+    @pytest.mark.unit
+    def test_none_return_is_wire_valid(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="side_effect_tool",
+            func=lambda: None,
+            schema={},
+            description="returns None by design",
+        )
+        server = MCPServer(mcp_instance=registry)
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {"name": "side_effect_tool", "arguments": {}},
+            }
+        )
+        assert response is not None
+        assert response["result"]["content"][0]["text"] == "null"
+
+
+class TestValidationModeCapability:
+    """Capabilities expose whether strict schema checks are active."""
+
+    @pytest.mark.unit
+    def test_default_mode_is_required_only(self) -> None:
+        assert _registry().get_capabilities()["validation_mode"] == "required_only"
+
+    @pytest.mark.unit
+    def test_strict_mode_is_advertised(self) -> None:
+        assert _registry(strict=True).get_capabilities()["validation_mode"] == (
+            "strict"
+        )

--- a/tests/mcp/test_tool_timeout.py
+++ b/tests/mcp/test_tool_timeout.py
@@ -1,0 +1,167 @@
+"""Tool-timeout enforcement contract tests (wave-2 MAJ-09).
+
+``MCPTool.timeout`` is registered, advertised in capabilities, and
+documented — these tests pin that it is also ENFORCED: the caller stops
+waiting at ``tool.timeout`` and receives ``MCPToolTimeoutError`` (wire code
+-32008, in the JSON-RPC server-defined range) on every transport, while
+un-timed tools keep the inline (unbounded) execution path.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.mcp
+
+from gnn.mcp.exceptions import MCPToolTimeoutError
+from gnn.mcp.mcp import MCP
+from gnn.mcp.server_core import MCPServer
+
+
+def _registry() -> MCP:
+    return MCP(enable_caching=False, enable_rate_limiting=False)
+
+
+class TestToolTimeoutEnforcement:
+    """execute_tool must bound the caller's wait at tool.timeout."""
+
+    @pytest.mark.unit
+    def test_hung_tool_raises_timeout_quickly(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="hung_tool",
+            func=lambda: time.sleep(1.5),
+            schema={},
+            description="sleeps past its timeout",
+            timeout=0.2,
+        )
+        start = time.monotonic()
+        with pytest.raises(MCPToolTimeoutError) as excinfo:
+            registry.execute_tool("hung_tool", {})
+        elapsed = time.monotonic() - start
+        assert excinfo.value.code == -32008
+        assert excinfo.value.data["tool_name"] == "hung_tool"
+        assert excinfo.value.data["timeout"] == 0.2
+        assert elapsed < 1.0  # bounded wait, not the full 1.5s sleep
+
+    @pytest.mark.unit
+    def test_timed_tool_completing_within_timeout_returns_result(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="quick_tool",
+            func=lambda: {"ok": True},
+            schema={},
+            description="fast",
+            timeout=5.0,
+        )
+        assert registry.execute_tool("quick_tool", {}) == {"ok": True}
+
+    @pytest.mark.unit
+    def test_untimed_tool_keeps_unbounded_inline_path(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="slow_untimed_tool",
+            func=lambda: {"finished": True},
+            schema={},
+            description="no timeout registered",
+        )
+        assert registry.execute_tool("slow_untimed_tool", {}) == {"finished": True}
+
+    @pytest.mark.unit
+    def test_timeout_counts_as_failed_request(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="hung_tool",
+            func=lambda: time.sleep(1.5),
+            schema={},
+            description="sleeps past its timeout",
+            timeout=0.1,
+        )
+        with pytest.raises(MCPToolTimeoutError):
+            registry.execute_tool("hung_tool", {})
+        assert registry._performance_metrics.failed_requests == 1
+        assert registry._performance_metrics.error_counts["hung_tool"] == 1
+        assert registry._error_count == 1
+
+    @pytest.mark.unit
+    def test_timeout_not_double_wrapped_as_execution_error(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="hung_tool",
+            func=lambda: time.sleep(1.5),
+            schema={},
+            description="sleeps past its timeout",
+            timeout=0.1,
+        )
+        with pytest.raises(MCPToolTimeoutError) as excinfo:
+            registry.execute_tool("hung_tool", {})
+        # -32008 (tool timeout), not -32603 (generic execution failure).
+        assert excinfo.value.code == -32008
+
+
+class TestTimeoutWireContract:
+    """The reserved code must reach JSON-RPC clients, not just the registry."""
+
+    @pytest.mark.unit
+    def test_server_core_maps_timeout_to_reserved_code(self) -> None:
+        registry = _registry()
+        registry.register_tool(
+            name="hung_tool",
+            func=lambda: time.sleep(1.5),
+            schema={},
+            description="sleeps past its timeout",
+            timeout=0.1,
+        )
+        server = MCPServer(mcp_instance=registry)
+        response: dict[str, Any] | None = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": "t-1",
+                "method": "tools/call",
+                "params": {"name": "hung_tool", "arguments": {}},
+            }
+        )
+        assert response is not None
+        assert response["id"] == "t-1"
+        assert response["error"]["code"] == -32008
+        assert "timed out" in response["error"]["message"]
+
+    @pytest.mark.unit
+    def test_stdio_transport_maps_timeout_to_reserved_code(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import queue as _queue
+
+        from gnn.mcp.server_stdio import StdioServer
+
+        registry = _registry()
+        registry.register_tool(
+            name="hung_tool",
+            func=lambda: time.sleep(1.5),
+            schema={},
+            description="sleeps past its timeout",
+            timeout=0.1,
+        )
+        monkeypatch.setattr("gnn.mcp.server_stdio.mcp_instance", registry)
+        server = StdioServer()
+        server._process_jsonrpc(
+            {
+                "jsonrpc": "2.0",
+                "id": "t-2",
+                "method": "mcp.tool.execute",
+                "params": {"name": "hung_tool", "params": {}},
+            }
+        )
+        messages: list[dict[str, Any]] = []
+        while True:
+            try:
+                messages.append(server.response_queue.get_nowait())
+            except _queue.Empty:
+                break
+        assert messages, "stdio transport must emit an error response"
+        error = messages[-1]
+        assert error["id"] == "t-2"
+        assert error["error"]["code"] == -32008


### PR DESCRIPTION
Wave-2 MED-01 (scoped in #62, implemented after the MAJ-08/09 work in #65):

- `execute_tool` now classifies `func(**params)` signature TypeErrors (unexpected/missing keyword arguments) as `MCPInvalidParamsError` (**-32602 INVALID_PARAMS**) instead of wrapping every TypeError into a -32603 'Internal error' with raw Python internals; in-body TypeErrors keep -32603
- `_validate_output` no longer rejects a `None` return with -32602: `MCPTool` declares no output contract (`returns` schema does not exist), so tools returning None are legitimate; the method stays as the extension point for a future contract
- `get_capabilities` exposes `validation_mode` ('strict' | 'required_only') — non-strict mode silently skipped all schema constraints beyond `required` while tools advertised them

New wire code space used: none (-32602 reused); no transport changes needed.

**Verification:** `tests/mcp/test_param_validation_fidelity.py` (8 tests: registry + server_core wire mapping, in-body TypeError stays -32603, None return wire-valid 'null', capability hints); 374 tests/mcp tests green; mypy 0 on src/gnn/mcp; ruff clean; session bench green (952 determinism checks).