### PR TITLE
fix: advisory-sweep cleanups on merged wave-2 orchestration work

### DIFF
--- a/src/gnn/mcp/mcp.py
+++ b/src/gnn/mcp/mcp.py
@@ -344,7 +344,7 @@ class MCP:
         sympy_mcp_file = mcp_dir / "sympy_mcp.py"
         if sympy_mcp_file.exists():
             try:
-                # Import directly as src.mcp.sympy_mcp since it's in the mcp directory
+                # Import directly as gnn.mcp.sympy_mcp since it's in the mcp directory
                 import_start = time.time()
                 sympy_module = importlib.import_module("gnn.mcp.sympy_mcp")
                 import_time = time.time() - import_start
@@ -374,7 +374,7 @@ class MCP:
                     logger.warning("sympy_mcp module has no register_tools function")
             except Exception as e:
                 logger.error(
-                    f"Failed to load core MCP module src.mcp.sympy_mcp: {str(e)}"
+                    f"Failed to load core MCP module gnn.mcp.sympy_mcp: {str(e)}"
                 )
                 all_modules_loaded_successfully = False
 

--- a/src/gnn/utils/pipeline_arguments.py
+++ b/src/gnn/utils/pipeline_arguments.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+DEFAULT_ONTOLOGY_TERMS_FILE = (
+    Path(__file__).resolve().parents[1] / "ontology" / "act_inf_ontology_terms.json"
+)
+"""Ontology terms file packaged inside the ``gnn`` package."""
+
 
 @dataclass
 class PipelineArguments:
@@ -135,14 +140,7 @@ class PipelineArguments:
 
         # Set defaults for optional paths
         if self.ontology_terms_file is None:
-            # Default to the ontology terms file packaged inside gnn
-            # (src/gnn/ontology/); repo-relative src/ontology/ is a retired
-            # pre-3.3.0 path.
-            self.ontology_terms_file = (
-                Path(__file__).resolve().parents[1]
-                / "ontology"
-                / "act_inf_ontology_terms.json"
-            )
+            self.ontology_terms_file = DEFAULT_ONTOLOGY_TERMS_FILE
         elif isinstance(self.ontology_terms_file, str):
             self.ontology_terms_file = Path(self.ontology_terms_file)
 

--- a/src/gnn/utils/test_utils.py
+++ b/src/gnn/utils/test_utils.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, cast
 
+from gnn.utils.pipeline_arguments import DEFAULT_ONTOLOGY_TERMS_FILE
 from gnn.utils.resource_manager import get_memory_usage
 
 # Ensure src is in Python path for imports
@@ -86,11 +87,7 @@ TEST_CONFIG: dict[str, Any] = {
     "dev": False,
     "duration": 30.0,
     "audio_backend": "auto",
-    "ontology_terms_file": PROJECT_ROOT
-    / "src"
-    / "gnn"
-    / "ontology"
-    / "act_inf_ontology_terms.json",
+    "ontology_terms_file": DEFAULT_ONTOLOGY_TERMS_FILE,
     "pipeline_summary_file": PROJECT_ROOT
     / "output"
     / "00_pipeline_summary"
@@ -418,9 +415,7 @@ def get_test_args() -> Dict[str, Any]:
         "dev": False,
         "duration": 30.0,
         "audio_backend": "auto",
-        "ontology_terms_file": str(
-            PROJECT_ROOT / "src" / "gnn" / "ontology" / "act_inf_ontology_terms.json"
-        ),
+        "ontology_terms_file": str(DEFAULT_ONTOLOGY_TERMS_FILE),
         "pipeline_summary_file": str(
             PROJECT_ROOT
             / "output"
@@ -443,9 +438,7 @@ def get_sample_pipeline_arguments() -> Dict[str, Any]:
         "only_steps": [],
         "strict": False,
         "estimate_resources": False,
-        "ontology_terms_file": str(
-            PROJECT_ROOT / "src" / "gnn" / "ontology" / "act_inf_ontology_terms.json"
-        ),
+        "ontology_terms_file": str(DEFAULT_ONTOLOGY_TERMS_FILE),
         "pipeline_summary_file": "output/00_pipeline_summary/pipeline_execution_summary.json",
         "llm_tasks": "all",
         "llm_timeout": 360,

--- a/tests/pipeline/test_pipeline_config.py
+++ b/tests/pipeline/test_pipeline_config.py
@@ -108,7 +108,7 @@ def test_get_output_dir_for_script_accepts_py_suffix(tmp_path: Path) -> None:
 
 
 def test_get_output_dir_for_script_warns_on_unregistered_stem(
-    tmp_path: Path, caplog: "pytest.LogCaptureFixture"
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Unregistered script names warn loudly, then keep the fallback path.
 


### PR DESCRIPTION
## Summary
Follow-up sweep verifying 15 advisory concerns against merged main (post PR #63/#64/#67). Five parallel read-only verification agents audited the gate harness, runtime validator probes, pipeline config, executor/ontology cluster, and export/health/format surface.

## Verified clean (no action)
- `autoresearch.sh`: single pytest invocation, `set +e` envelope, `--no-sync`, no dup redirect, `bash -n` OK, METRIC contract intact
- `pipeline_runtime_validator.py`: all 4 probes `Path(__file__)`-anchored, 5/5 pinned files exist, each probe justified (pymdp regression guard, live jax/julia template contracts, dependency-handling)
- `config.py`: `_CONFIG_PARSE_ERRORS` concat-form tuple, ERROR-level parse log with path + typed caplog test, no dup comments, unknown-stem warning placement, `resolve_step_output_dir` walk climbs any `*_output` ancestor (probed all 3 cases), legacy resolver names intact
- executor.py cutover, pipeline_template alias/`__getattr__` with no internal callers, public `gnn.utils` re-export works
- 7_export registry ↔ real entry match; Julia remediation strings match actual executor `--project=` constants; `ruff format --check src scripts` clean

## Fixed
1. **Ontology default constant**: export `DEFAULT_ONTOLOGY_TERMS_FILE` from `pipeline_arguments.py`; consume it in `__post_init__` and all three `test_utils.py` fixture sites (removes drift-prone duplicated `PROJECT_ROOT` path expressions)
2. **Stale retired-surface text** in `mcp.py:347,377` — comment + user-facing error log said `src.mcp.sympy_mcp`; actual import is `gnn.mcp.sympy_mcp`
3. **Quoted annotation artifact** `"pytest.LogCaptureFixture"` → unquoted in `test_pipeline_config.py:111`

## Verification
- ruff check + format (CI command `src scripts`): clean, 658 files
- mypy on touched src: clean
- terminology gate: clean
- tests: 237 utils, 50 pipeline (config/health/registry), MCP skills-health audit 0 findings