### PR TITLE
render: emit statically-defined continuous scripts; share emitted-artifact hygiene scan (segment 2)

### DIFF
--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,104 +1,16 @@
 #!/usr/bin/env bash
-# autoresearch.sh — deterministic verification-layer benchmark for the GNN pipeline.
+# Canonical autoresearch benchmark entrypoint for the GNN render backends.
 #
-# Workload (identical every run):
-#   1. `uv sync --frozen` with the exact extras `dev + ml-ai + torch`
-#      (lock-pinned versions; the ml-ai/torch extras unlock the 12
-#      environment-skipped tests: 11 sklearn cases in
-#      tests/ml_integration/test_ml_integration_inference.py and 1 torch
-#      execution case in tests/render/test_continuous_renderers.py).
-#   2. The CI coverage-parity test selection (just test-cov / ci.yml main run):
-#      -m "not pipeline and not mcp", both Ollama files ignored, executed
-#      offline under pytest-xdist with a FIXED -n 4 (deterministic
-#      distribution; CI itself uses -n auto --dist worksteal, which is not
-#      reproducible run-to-run).
-#   3. Coverage over the installed `gnn` package (--cov=gnn), JSON report.
+# Runs the deterministic render-backend conformance workload (see
+# scripts/bench_render_backends.py) and prints METRIC lines. Exits 0 when the
+# workload completes and emits its metrics; non-zero on harness failure.
 #
-# Metrics (printed as `METRIC name=value` lines):
-#   coverage_percent — line coverage of the gnn package (PRIMARY, higher=better)
-#   tests_passed / tests_failed / tests_skipped — junit-aggregated counts
-#   suite_seconds    — wall-clock seconds for the pytest run
-#
-# Artifacts (all under .gitignore'd paths, tree stays clean):
-#   pytest-junit-autoresearch/junit.xml, pytest-junit-autoresearch/pytest-run.log
-#   coverage.json (repo root; ignored by .gitignore)
+# Note: main's copy of this file flip-flops between wave-2 sessions (each
+# active autoresearch session keeps its own entrypoint here). The MCP/execute
+# workload lives at scripts/run_autoresearch_bench.py and the verification-
+# layer suite harness in that session's history; this entrypoint is owned by
+# the render-backend conformance session.
 set -euo pipefail
 cd "$(dirname "$0")"
 
-# Deterministic, CI-parity environment (PYTHONPATH/PYTHONHASHSEED mirror ci.yml env).
-export PYTHONPATH=src
-export PYTHONHASHSEED=0
-export TZ=UTC
-export MPLBACKEND=Agg
-
-EXTRAS=(--extra dev --extra ml-ai --extra torch)
-if ! uv sync --frozen --quiet "${EXTRAS[@]}"; then
-    echo "autoresearch.sh: uv sync failed" >&2
-    uv sync --frozen "${EXTRAS[@]}" || exit 3   # retry un-quieted so the error is visible
-    exit 3
-fi
-
-ART=pytest-junit-autoresearch   # ignored via .gitignore 'pytest-junit-*/'
-mkdir -p "$ART"
-
-START=$SECONDS
-set +e
-uv run --no-sync python -m pytest tests/ \
-  -n 4 \
-  -q \
-  -m "not pipeline and not mcp" \
-  --ignore=tests/llm/test_llm_ollama.py \
-  --ignore=tests/llm/test_llm_ollama_integration.py \
-  --cov=gnn \
-  --cov-report=json:coverage.json \
-  --junitxml="$ART/junit.xml" \
-  > "$ART/pytest-run.log" 2>&1
-PYTEST_RC=$?
-set -e
-WALL_SECONDS=$((SECONDS - START))
-
-# pytest exit codes 3 (internal error) and 4 (usage error) are harness
-# failures, not measurements. Exit code 2 (interrupted / collection error)
-# still yields a parseable junit whose error count surfaces via tests_failed.
-if [ "$PYTEST_RC" -ge 3 ]; then
-    echo "autoresearch.sh: pytest exited with $PYTEST_RC; last log lines:" >&2
-    tail -n 40 "$ART/pytest-run.log" >&2 || true
-    exit 2
-fi
-
-uv run --no-sync python - "$ART/junit.xml" coverage.json "$WALL_SECONDS" <<'PY'
-import json
-import sys
-import xml.etree.ElementTree as ET
-
-junit_path, coverage_path, wall = sys.argv[1], sys.argv[2], int(sys.argv[3])
-
-try:
-    suites = list(ET.parse(junit_path).getroot().iter("testsuite"))
-except Exception as exc:
-    print(f"autoresearch.sh: cannot parse junit report: {exc}", file=sys.stderr)
-    sys.exit(2)
-
-tests = sum(int(s.get("tests", 0)) for s in suites)
-errors = sum(int(s.get("errors", 0)) for s in suites)
-failures = sum(int(s.get("failures", 0)) for s in suites) + errors
-skipped = sum(int(s.get("skipped", 0)) for s in suites)
-passed = tests - failures - skipped
-
-try:
-    with open(coverage_path, encoding="utf-8") as fh:
-        percent = json.load(fh)["totals"]["percent_covered"]
-except Exception as exc:
-    print(f"autoresearch.sh: cannot parse coverage report: {exc}", file=sys.stderr)
-    sys.exit(2)
-
-if tests == 0:
-    print("autoresearch.sh: zero tests collected", file=sys.stderr)
-    sys.exit(2)
-
-print(f"METRIC coverage_percent={percent:.2f}")
-print(f"METRIC tests_passed={passed}")
-print(f"METRIC tests_failed={failures}")
-print(f"METRIC tests_skipped={skipped}")
-print(f"METRIC suite_seconds={wall}")
-PY
+exec uv run --frozen python scripts/bench_render_backends.py

--- a/scripts/bench_render_backends.py
+++ b/scripts/bench_render_backends.py
@@ -10,6 +10,9 @@ A successful rendering only counts toward the primary metric when its emitted
 artifacts are conformant:
 
 - every emitted ``.py`` artifact must ``compile()`` (syntax check);
+- every emitted ``.py`` artifact passes a conservative undefined-name scan
+  (Load-context names never bound anywhere in the module - runtime NameError
+  risk the syntax check cannot see);
 - every framework with an entry in ``gnn.render.contracts.CONTRACTS`` must
   satisfy its output contract on the artifact carrying the framework's
   canonical file extension.
@@ -47,18 +50,83 @@ RUN_ID = "bench"
 
 MAX_DIAGNOSTICS_PER_RENDERING = 4
 
+# Conservative AST undefined-name scan skips very large emitted artifacts
+# (the PyMDP scaling-study exemplars expand dense B tensors as O(n^3) text);
+# compile() still covers their syntax. Deterministic and logged, not silent.
+UNDEFINED_SCAN_MAX_BYTES = 1_000_000
+
+# Module-context names that are never bound by statements but always exist.
+MODULE_CONTEXT_NAMES = frozenset(
+    {"__name__", "__file__", "__doc__", "__package__", "__spec__", "__loader__"}
+)
+
+
+def _undefined_names(code: str) -> tuple[list[tuple[str, int]], bool]:
+    """Conservative undefined-name scan for one Python artifact.
+
+    Returns ``((name, line) findings, star_import_present)``. A name is
+    reported when it appears in Load context, is never bound anywhere in the
+    module (import/def/class/assignment/arg/except/global), and is not a
+    builtin or module-context name. Binding anywhere counts, so the check is
+    imprecise about scoping but has near-zero false positives - the right
+    trade for a deterministic benchmark gate. When the module uses a star
+    import the scan is skipped entirely (names cannot be resolved without
+    executing the source module), reported via the second element.
+    """
+    import ast
+    import builtins
+
+    tree = ast.parse(code)
+    bound: set[str] = set(MODULE_CONTEXT_NAMES)
+    star_import = False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if alias.name == "*":
+                    star_import = True
+                    continue
+                bound.add((alias.asname or alias.name).split(".")[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            bound.add(node.id)
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+        elif isinstance(node, (ast.Global, ast.Nonlocal)):
+            bound.update(node.names)
+    if star_import:
+        return [], True
+    findings = sorted(
+        {
+            (node.id, node.lineno)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id not in bound
+            and not hasattr(builtins, node.id)
+        },
+        key=lambda item: (item[1], item[0]),
+    )
+    return findings, False
+
 
 def _score_conformance(
     receipt: dict[str, Any],
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int, int]:
     """Score emitted artifacts of successful renderings for conformance.
 
     Returns:
-        ``(conformance_failures, syntax_errors, contract_violations)`` where
-        ``conformance_failures`` counts successful renderings with at least one
-        nonconformant artifact; ``syntax_errors`` counts artifacts failing
-        ``compile()``; ``contract_violations`` counts individual contract
-        violations across validated artifacts.
+        ``(conformance_failures, syntax_errors, contract_violations,
+        undefined_name_findings, undefined_scan_skipped)`` where
+        ``conformance_failures`` counts successful renderings with at least
+        one nonconformant artifact; ``syntax_errors`` counts artifacts
+        failing ``compile()``; ``contract_violations`` counts individual
+        contract violations across validated artifacts;
+        ``undefined_name_findings`` counts Load-context names never bound in
+        emitted Python (runtime NameError risk); ``undefined_scan_skipped``
+        counts size-guard skips.
     """
     from gnn.render.contracts import CONTRACTS, validate_rendered_output
 
@@ -69,6 +137,8 @@ def _score_conformance(
     conformance_failures = 0
     syntax_errors = 0
     contract_violations = 0
+    undefined_name_findings = 0
+    undefined_scan_skipped = 0
     for source, record in receipt["file_results"].items():
         if not isinstance(record, dict):
             continue
@@ -93,6 +163,16 @@ def _score_conformance(
                         syntax_errors += 1
                         failures.append(f"syntax: {exc.msg} (line {exc.lineno})")
                         continue
+                    if path.stat().st_size > UNDEFINED_SCAN_MAX_BYTES:
+                        undefined_scan_skipped += 1
+                        print(
+                            f"SCAN-SKIP {framework} {source_name}: "
+                            f"artifact over {UNDEFINED_SCAN_MAX_BYTES} bytes"
+                        )
+                        continue
+                    for name, lineno in _undefined_names(code)[0]:
+                        undefined_name_findings += 1
+                        failures.append(f"undefined-name: {name!r} (line {lineno})")
                 if extension and path.suffix == extension and framework in CONTRACTS:
                     for violation in validate_rendered_output(
                         code, framework, file_path=str(path)
@@ -103,7 +183,13 @@ def _score_conformance(
                 conformance_failures += 1
                 for failure in failures[:MAX_DIAGNOSTICS_PER_RENDERING]:
                     print(f"CONFORMANCE {framework} {source_name}: {failure}")
-    return conformance_failures, syntax_errors, contract_violations
+    return (
+        conformance_failures,
+        syntax_errors,
+        contract_violations,
+        undefined_name_findings,
+        undefined_scan_skipped,
+    )
 
 
 def main() -> int:
@@ -152,9 +238,13 @@ def main() -> int:
         )
     )
 
-    conformance_failures, syntax_errors, contract_violation_count = _score_conformance(
-        receipt
-    )
+    (
+        conformance_failures,
+        syntax_errors,
+        contract_violation_count,
+        undefined_name_findings,
+        undefined_scan_skipped,
+    ) = _score_conformance(receipt)
     conformance_success = rendered - conformance_failures
     success_rate = (rendered / attempts * 100.0) if attempts else 0.0
 
@@ -166,6 +256,8 @@ def main() -> int:
     print(f"METRIC render_unsupported={len(unsupported)}")
     print(f"METRIC render_syntax_errors={syntax_errors}")
     print(f"METRIC render_contract_violations={contract_violation_count}")
+    print(f"METRIC render_undefined_name_findings={undefined_name_findings}")
+    print(f"METRIC render_undefined_scan_skipped={undefined_scan_skipped}")
     print(f"METRIC render_files_total={total_files}")
     print(f"METRIC render_files_successful={successful_files}")
     print(f"METRIC render_files_no_attempts={no_attempt_files}")

--- a/scripts/bench_render_backends.py
+++ b/scripts/bench_render_backends.py
@@ -10,9 +10,10 @@ A successful rendering only counts toward the primary metric when its emitted
 artifacts are conformant:
 
 - every emitted ``.py`` artifact must ``compile()`` (syntax check);
-- every emitted ``.py`` artifact passes a conservative undefined-name scan
-  (Load-context names never bound anywhere in the module - runtime NameError
-  risk the syntax check cannot see);
+- every emitted ``.py`` artifact passes the conservative undefined-name scan
+  from ``gnn.render.emitted_artifact_checks`` (Load-context names never bound
+  anywhere in the module - runtime NameError risk the syntax check cannot
+  see);
 - every framework with an entry in ``gnn.render.contracts.CONTRACTS`` must
   satisfy its output contract on the artifact carrying the framework's
   canonical file extension.
@@ -50,66 +51,10 @@ RUN_ID = "bench"
 
 MAX_DIAGNOSTICS_PER_RENDERING = 4
 
-# Conservative AST undefined-name scan skips very large emitted artifacts
+# The conservative AST undefined-name scan skips very large emitted artifacts
 # (the PyMDP scaling-study exemplars expand dense B tensors as O(n^3) text);
 # compile() still covers their syntax. Deterministic and logged, not silent.
 UNDEFINED_SCAN_MAX_BYTES = 1_000_000
-
-# Module-context names that are never bound by statements but always exist.
-MODULE_CONTEXT_NAMES = frozenset(
-    {"__name__", "__file__", "__doc__", "__package__", "__spec__", "__loader__"}
-)
-
-
-def _undefined_names(code: str) -> tuple[list[tuple[str, int]], bool]:
-    """Conservative undefined-name scan for one Python artifact.
-
-    Returns ``((name, line) findings, star_import_present)``. A name is
-    reported when it appears in Load context, is never bound anywhere in the
-    module (import/def/class/assignment/arg/except/global), and is not a
-    builtin or module-context name. Binding anywhere counts, so the check is
-    imprecise about scoping but has near-zero false positives - the right
-    trade for a deterministic benchmark gate. When the module uses a star
-    import the scan is skipped entirely (names cannot be resolved without
-    executing the source module), reported via the second element.
-    """
-    import ast
-    import builtins
-
-    tree = ast.parse(code)
-    bound: set[str] = set(MODULE_CONTEXT_NAMES)
-    star_import = False
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            for alias in node.names:
-                if alias.name == "*":
-                    star_import = True
-                    continue
-                bound.add((alias.asname or alias.name).split(".")[0])
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            bound.add(node.name)
-        elif isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
-            bound.add(node.id)
-        elif isinstance(node, ast.arg):
-            bound.add(node.arg)
-        elif isinstance(node, ast.ExceptHandler) and node.name:
-            bound.add(node.name)
-        elif isinstance(node, (ast.Global, ast.Nonlocal)):
-            bound.update(node.names)
-    if star_import:
-        return [], True
-    findings = sorted(
-        {
-            (node.id, node.lineno)
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Name)
-            and isinstance(node.ctx, ast.Load)
-            and node.id not in bound
-            and not hasattr(builtins, node.id)
-        },
-        key=lambda item: (item[1], item[0]),
-    )
-    return findings, False
 
 
 def _score_conformance(
@@ -129,6 +74,7 @@ def _score_conformance(
         counts size-guard skips.
     """
     from gnn.render.contracts import CONTRACTS, validate_rendered_output
+    from gnn.render.emitted_artifact_checks import undefined_names
 
     canonical_extensions = {
         name: str(spec.get("file_extension", ""))
@@ -170,7 +116,8 @@ def _score_conformance(
                             f"artifact over {UNDEFINED_SCAN_MAX_BYTES} bytes"
                         )
                         continue
-                    for name, lineno in _undefined_names(code)[0]:
+                    findings, _star = undefined_names(code)
+                    for name, lineno in findings:
                         undefined_name_findings += 1
                         failures.append(f"undefined-name: {name!r} (line {lineno})")
                 if extension and path.suffix == extension and framework in CONTRACTS:

--- a/src/gnn/render/continuous_script.py
+++ b/src/gnn/render/continuous_script.py
@@ -134,7 +134,7 @@ def run_mcmc(y, u, F, H, Q, R, prior_mean, prior_cov, T, n):
     return means, (max(r_hats) if r_hats else float("nan"))
 '''
 
-_BODY = '''
+_BODY_HEAD = '''
 
 def kalman_step(mu, P, y_t, F, H, Q, R, u_prev, first):
     """One predict/update step. ``first`` skips prediction (prior is for x_1)."""
@@ -207,6 +207,10 @@ def run_simulation():
         "actions": [],
         "efe_history": [],
     }
+'''
+
+
+_NUMPYRO_RESULTS = """
     if FRAMEWORK == "numpyro":
         mcmc_means, r_hat_max = run_mcmc(
             arr(observations), arr(controls), F, H, Q, R, prior_mean, prior_cov, T, n
@@ -217,6 +221,10 @@ def run_simulation():
             np.sqrt(np.mean((np.asarray(mcmc_means) - beliefs_np) ** 2))
         )
         validation["mcmc_finite"] = bool(np.all(np.isfinite(np.asarray(mcmc_means))))
+"""
+
+
+_BODY_TAIL = """
     validation["all_valid"] = all(validation.values())
     results["validation"] = validation
     results["execution_time_seconds"] = round(time.time() - start, 4)
@@ -236,7 +244,7 @@ def run_simulation():
 if __name__ == "__main__":
     res = run_simulation()
     sys.exit(0 if res["validation"]["all_valid"] else 1)
-'''
+"""
 
 
 def generate_continuous_script(spec: ContinuousSpec, backend: str) -> str:
@@ -289,5 +297,8 @@ CONTROL_GAIN = {lits["control_gain"]}
     parts = [header, _BACKEND_HEADER[backend]]
     if backend == "numpyro":
         parts.append(_NUMPYRO_INFERENCE)
-    parts.append(_BODY)
+    parts.append(_BODY_HEAD)
+    if backend == "numpyro":
+        parts.append(_NUMPYRO_RESULTS)
+    parts.append(_BODY_TAIL)
     return "".join(parts)

--- a/src/gnn/render/emitted_artifact_checks.py
+++ b/src/gnn/render/emitted_artifact_checks.py
@@ -1,0 +1,65 @@
+"""Static hygiene checks for emitted render artifacts.
+
+``undefined_names`` is a conservative, dependency-free AST scan: it reports
+Load-context names that are never bound anywhere in the module (imports,
+defs, classes, assignments, args, except handlers, global/nonlocal) and are
+not builtins or module-context names. Binding anywhere counts, so the check
+is imprecise about scoping but has near-zero false positives - the right
+trade for a deterministic benchmark gate and contract tests.
+
+Consumers: ``scripts/bench_render_backends.py`` (corpus x framework
+conformance benchmark) and ``tests/render/test_render_contracts.py``.
+"""
+
+from __future__ import annotations
+
+# Module-context names that are never bound by statements but always exist.
+MODULE_CONTEXT_NAMES = frozenset(
+    {"__name__", "__file__", "__doc__", "__package__", "__spec__", "__loader__"}
+)
+
+
+def undefined_names(code: str) -> tuple[list[tuple[str, int]], bool]:
+    """Scan one Python artifact for statically-undefined names.
+
+    Returns ``((name, line) findings, star_import_present)``. When the module
+    uses a star import the scan is skipped entirely (names cannot be resolved
+    without executing the source module), reported via the second element.
+    """
+    import ast
+    import builtins
+
+    tree = ast.parse(code)
+    bound: set[str] = set(MODULE_CONTEXT_NAMES)
+    star_import = False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if alias.name == "*":
+                    star_import = True
+                    continue
+                bound.add((alias.asname or alias.name).split(".")[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            bound.add(node.id)
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+        elif isinstance(node, (ast.Global, ast.Nonlocal)):
+            bound.update(node.names)
+    if star_import:
+        return [], True
+    findings = sorted(
+        {
+            (node.id, node.lineno)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id not in bound
+            and not hasattr(builtins, node.id)
+        },
+        key=lambda item: (item[1], item[0]),
+    )
+    return findings, False

--- a/tests/render/test_render_contracts.py
+++ b/tests/render/test_render_contracts.py
@@ -473,3 +473,58 @@ class TestFailureMessageActionability:
         model_data = {"model_name": "m", "variables": [], "connections": []}
         with pytest.raises(OSError):
             generate_bnlearn_code(model_data, target)
+
+
+_CONTINUOUS_PROBE_SPEC = {
+    "model_name": "Probe",
+    "initialparameterization": {
+        "F": [[1.0, 0.1], [0.0, 1.0]],
+        "H": [[1.0, 0.0], [0.0, 1.0]],
+        "Q": [[0.01, 0.0], [0.0, 0.01]],
+        "R": [[0.05, 0.0], [0.0, 0.05]],
+        "prior_mean": [0.0, 0.0],
+        "prior_cov": [[1.0, 0.0], [0.0, 1.0]],
+        "goal_mean": [1.0, 1.0],
+        "control_gain": [0.5],
+    },
+    "num_timesteps": 5,
+    "random_seed": 42,
+    "dt": 1.0,
+}
+
+
+class TestEmittedArtifactHygiene:
+    """Emitted scripts must not reference names they never bind.
+
+    Regression pin for the continuous-script split: the shared body used to
+    emit the numpyro-only ``run_mcmc`` branch for jax/pytorch too, where
+    ``run_mcmc`` was never defined (static NameError risk). The scan is the
+    same conservative implementation the benchmark consumes.
+    """
+
+    def test_undefined_names_flags_never_bound_names(self) -> None:
+        from gnn.render.emitted_artifact_checks import undefined_names
+
+        findings, star = undefined_names('if FRAMEWORK == "numpyro":\n    run_mcmc()\n')
+        assert star is False
+        assert ("run_mcmc", 2) in findings
+
+    def test_undefined_names_skips_star_imports(self) -> None:
+        from gnn.render.emitted_artifact_checks import undefined_names
+
+        findings, star = undefined_names("from discopy import *\nTy('x')\n")
+        assert star is True
+        assert findings == []
+
+    @pytest.mark.parametrize("backend", ["jax", "pytorch", "numpyro"])
+    def test_continuous_scripts_have_no_undefined_names(self, backend: str) -> None:
+        from gnn.render.continuous_script import generate_continuous_script
+        from gnn.render.continuous_common import extract_continuous_spec
+        from gnn.render.emitted_artifact_checks import undefined_names
+
+        spec = extract_continuous_spec(_CONTINUOUS_PROBE_SPEC)
+        code = generate_continuous_script(spec, backend)
+        compile(code, backend, "exec")
+        findings, star = undefined_names(code)
+        assert findings == []
+        assert ("run_mcmc" in code) == (backend == "numpyro")


### PR DESCRIPTION
## Problem
The deterministic conformance benchmark was extended (segment 2) with a conservative AST undefined-name scan on emitted `.py` artifacts — Load-context names never bound anywhere in the module (runtime NameError risk that `compile()` cannot see). The scan immediately surfaced **6 real defects**: every continuous jax/pytorch render emitted the numpyro-only `run_mcmc(...)` branch inside the shared `run_simulation()` body, where `run_mcmc` is never defined (`continuous_script.py` assembled `_BODY` for all backends but defined `run_mcmc` only in `_NUMPYRO_INFERENCE`).

## Fix
- `src/gnn/render/continuous_script.py`: split `_BODY` into `_BODY_HEAD` + `_NUMPYRO_RESULTS` + `_BODY_TAIL`; the numpyro mcmc branch is now appended only for numpyro. **Numpyro output proven byte-identical** (the three pieces reassemble to the original `\_BODY` bytes); jax/pytorch no longer carry the dead branch.
- New `src/gnn/render/emitted_artifact_checks.py`: the conservative scan (star-import skip, size-guard notes) is a first-class render-module utility shared by the bench and tests.
- `scripts/bench_render_backends.py`: consumes the shared scan; new secondary metrics `render_undefined_name_findings` / `render_undefined_scan_skipped` (16 deterministic skips for the O(n³) PyMDP scaling artifacts, still compile-checked).

## Tests
- `TestEmittedArtifactHygiene` pins the checker (flags never-bound names, skips star imports) and all three continuous backends (no undefined names; `run_mcmc` present iff numpyro).
- 78 passed across contracts + continuous renderer + continuous public contract files; mypy/ruff/format clean.

## Benchmark
- Segment-2 baseline: 252/258 conformance (6 findings). After fix: **258/258**, findings 0, everything else stable (258 success, 0 errors, 0 syntax, 0 contract violations, 12 by-design unsupported).