### PR TITLE
docs(todo): add scope evidence for wave-2 remainders

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -147,6 +147,17 @@ in-memory propagation (steps 5/6/8/10/11/13 re-parse input; only 3→7 and
 11→12 consume artifacts). `run_session`/durable streams are not wired into
 main.py composition (feature gap, not a test gap). These need a design
 decision, not a mechanical fix.
+
+Scope evidence (verified 2026-09-08 against main, post-PR-#69): the
+coverage floor is `fail_under = 50` (pyproject.toml:397), so deleting the
+`test_pipeline_overall.py` hasattr-façade checks is coverage-safe and
+needs no replacement padding. `PipelineContext` removal surface is closed:
+10 files, all inside `src/gnn/pipeline/context.py`, its dedicated test
+`tests/pipeline/test_pipeline_context.py`, the re-export pair in
+`pipeline/__init__.py` (import + `__all__`), and two AGENTS.md doc lines
+(:148, :483) — zero production callers; removal is mechanical once the
+delete-vs-wire-in decision is made.
+
 ## Deep horizon wave 2 - render backends
 
 Scoping for `src/gnn/render/**` (2026-09-08, deep-horizon session). RB-01


### PR DESCRIPTION
Follow-up to #69. Two remainder premises verified against main and recorded in the wave-2 orchestration subsection (evidence only, no scope change):

1. **Coverage floor**: `fail_under = 50` at `pyproject.toml:397` — deleting the `test_pipeline_overall.py` hasattr-façade checks is coverage-safe (refines the handoff claim that deletion 'risks the coverage gate').
2. **PipelineContext removal surface**: verified closed — 10 files, all inside `context.py` + its dedicated test + the `pipeline/__init__.py` re-export pair + 2 AGENTS.md lines; zero production callers. Removal is mechanical once delete-vs-wire-in is decided.

Doc gates locally: terminology, maintained-doc-terms, doc-path-references, gnn-doc-patterns — all clean.