### PR TITLE
fix(mcp): real resource lister, HTTP capability/read gate agreement, docs drift (MED-02)

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -23,10 +23,11 @@ MCP servers expose tools over STDIO or HTTP: bind listeners to localhost in untr
 Each functional module includes its own `mcp.py` file that registers domain-specific tools:
 
 ```
-src/
-├── mcp/               # Core MCP infrastructure
+src/gnn/
+├── mcp/               # Core MCP infrastructure (registry, transports)
 ├── export/mcp.py      # Export format tools
-├── gnn/mcp.py         # GNN parsing and validation tools
+├── gnn/mcp.py         # GNN parsing and validation tools (loaded via mcp/gnn_root.py)
+├── gui/mcp.py         # GUI tools (including oxdraw.* wrappers)
 ├── ontology/mcp.py    # Ontology processing tools
 ├── visualization/mcp.py # Visualization generation tools
 └── llm/mcp.py         # LLM integration tools

--- a/src/gnn/mcp/AGENTS.md
+++ b/src/gnn/mcp/AGENTS.md
@@ -137,11 +137,14 @@ on the live execution path.
 #### `MCPResource` - Resource Definition Class
 **Description**: Represents accessible MCP resources
 
-**Attributes**:
-- `uri` - Resource URI
-- `name` - Resource name
+**Attributes** (see `src/gnn/mcp/models.py` for the dataclass):
+- `uri_template` - URI template (e.g. `gnn://documentation/{doc_name}`)
+- `retriever` - Callable returning the resource content
 - `description` - Resource description
-- `mime_type` - Resource MIME type
+- `module` / `category` / `version` - Provenance metadata
+- `mime_type` - Resource MIME type (default `application/json`)
+- `cacheable` - Whether the resource may be cached
+- `tags` - Free-form tags
 
 ### Transport Protocols
 

--- a/src/gnn/mcp/README.md
+++ b/src/gnn/mcp/README.md
@@ -255,9 +255,20 @@ The MCP implementation provides comprehensive error handling:
 
 ### Custom MCP Error Codes
 - `-32000`: MCP-specific errors
-- `-32001`: Tool execution errors
-- `-32002`: Resource retrieval errors
+- `-32001`: HTTP not-exposed (tool not on the HTTP safe allowlist)
+- `-32002`: HTTP not-exposed (resource not on the HTTP safe allowlist)
 - `-32003`: Module loading errors
+- `-32004`: Performance threshold exceeded
+- `-32005`: Rate limit exceeded
+- `-32006`: Cache operation failed
+- `-32007`: Module discovery failed
+- `-32008`: Tool execution timed out (wave-2 MAJ-09; enforced via MCPTool.timeout)
+
+JSON-RPC reserved codes are used where the spec defines them:
+- `-32601` (Method not found) is raised for an unknown tool AND for a
+  missing resource (`MCPResourceNotFoundError`), not `-32002`.
+- `-32602` (Invalid params) covers invalid tool arguments.
+- `-32603` (Internal error) covers unhandled execution failures.
 
 ### Error Response Format
 ```json

--- a/src/gnn/mcp/__init__.py
+++ b/src/gnn/mcp/__init__.py
@@ -51,6 +51,7 @@ def list_available_resources() -> list:
 
     return list(mcp_instance.list_available_resources())
 
+
 # -- Module metadata -----------------------------------------------------------------
 __version__ = "3.3.0"
 __author__ = "Active Inference Institute"

--- a/src/gnn/mcp/__init__.py
+++ b/src/gnn/mcp/__init__.py
@@ -32,9 +32,24 @@ from .server import MCPServer as _JSONRPCServer  # noqa: E402
 MCPServer = _JSONRPCServer
 JSONRPCServer = _JSONRPCServer
 
-# list_available_tools and list_available_resources are aliases for get_available_tools
+# ``list_available_tools`` is an alias for ``get_available_tools``. Historically
+# ``list_available_resources`` was the SAME alias — i.e. it returned the tool
+# list, not the resource list. It now delegates to the real resource lister
+# (``MCP.list_available_resources``); the old tools-list-aliased behavior is a
+# contract bug, not an intent.
 list_available_tools = get_available_tools
-list_available_resources = get_available_tools
+
+
+def list_available_resources() -> list:
+    """Return metadata for every registered MCP resource (delegates to MCP).
+
+    Previously this symbol aliased ``get_available_tools`` and returned the
+    tool list mislabelled as resources; it now returns the real resource
+    list (same shape as ``MCP.list_available_resources``).
+    """
+    from .mcp import mcp_instance  # late import keeps package import light
+
+    return list(mcp_instance.list_available_resources())
 
 # -- Module metadata -----------------------------------------------------------------
 __version__ = "3.3.0"

--- a/src/gnn/mcp/npx_inspector.py
+++ b/src/gnn/mcp/npx_inspector.py
@@ -156,19 +156,13 @@ class StdioMCPClient:
         return self._send_request(method=tool_name, params=tool_params)
 
     def get_resource(self, uri: str) -> dict:
-        # This might require a specific method name if not using raw URI as method
-        # For now, assuming a hypothetical "resource/get" method, or that resource URIs are tools.
-        # The GNN `cli.py` 'resource' command implies resource URIs are distinct.
-        # Let's assume a tool like `meta.get_resource_content` for now, or adjust if GNN MCP has a specific one.
-        # Based on GNN MCP spec, there isn't a generic "get resource" tool.
-        # Resources are typically outputs of other tools. This function might be less useful directly.
-        # For now, let's make it try to call the URI as if it were a tool (unlikely to work).
+        # Resources are read via the standard ``mcp.resource.get`` MCP method,
+        # not via a raw URI as method. The earlier guess-work (sending the URI
+        # as a method name) could never retrieve a resource.
         """Return resource."""
-        print(
-            "INSPECTOR (warning): Direct resource GET not well-defined in GNN MCP. Trying URI as method.",
-            file=sys.stderr,
+        return self._send_request(
+            method="mcp.resource.get", params={"uri": uri}
         )
-        return self._send_request(method=uri)  # This is a guess
 
 
 # --- CLI Subcommands ---

--- a/src/gnn/mcp/npx_inspector.py
+++ b/src/gnn/mcp/npx_inspector.py
@@ -160,9 +160,7 @@ class StdioMCPClient:
         # not via a raw URI as method. The earlier guess-work (sending the URI
         # as a method name) could never retrieve a resource.
         """Return resource."""
-        return self._send_request(
-            method="mcp.resource.get", params={"uri": uri}
-        )
+        return self._send_request(method="mcp.resource.get", params={"uri": uri})
 
 
 # --- CLI Subcommands ---

--- a/src/gnn/mcp/server_http.py
+++ b/src/gnn/mcp/server_http.py
@@ -182,9 +182,48 @@ def is_safe_http_tool(tool_name: str) -> bool:
     return True if safe_tools is None else tool_name in safe_tools
 
 
+def _safe_resource_match(safe_resources: set[str], template_or_uri: str) -> bool:
+    """Decide whether a configured safe URI exposes a resource.
+
+    A registered resource carries a templated ``uri_template`` (e.g.
+    ``gnn://documentation/{doc_name}``) while operators configure concrete
+    URIs in ``GNN_MCP_SAFE_RESOURCES`` (e.g.
+    ``gnn://documentation/grammar``). An exact string match handles both
+    shapes; a template match falls back to the MCP URI matcher so one
+    concrete entry can expose the whole template it instantiates.
+
+    ``template_or_uri`` may be either a template (when filtering capabilities)
+    or a concrete URI (when gating a read). Both directions must agree.
+    """
+    if template_or_uri in safe_resources:
+        return True
+    registered = mcp_instance.resources
+    for configured in safe_resources:
+        for template, resource in registered.items():
+            if resource is None:
+                continue
+            if configured == template:
+                # The configured URI is a template; accept any matching URI.
+                if mcp_instance._match_uri_template(template, template_or_uri):
+                    return True
+            elif mcp_instance._match_uri_template(template, configured):
+                # The configured URI is concrete under this template.
+                if template_or_uri == configured:
+                    # Concrete read gate: the concrete URI is the one configured.
+                    return True
+                if template_or_uri == template:
+                    # Capabilities filter: the template itself is exposed
+                    # because one of its concrete URIs is configured.
+                    return True
+    return False
+
+
 def is_safe_http_resource(uri: str) -> bool:
     """Return True when a resource URI is explicitly exposed over HTTP."""
-    return uri in get_safe_http_resource_uris()
+    safe_resources = get_safe_http_resource_uris()
+    if not safe_resources:
+        return False
+    return _safe_resource_match(safe_resources, uri)
 
 
 def get_http_capabilities() -> Dict[str, Any]:
@@ -200,12 +239,15 @@ def get_http_capabilities() -> Dict[str, Any]:
             for tool in tools
             if isinstance(tool, dict) and str(tool.get("name")) in safe_tools
         ]
-    resources = [
-        resource
-        for resource in resources
-        if isinstance(resource, dict)
-        and str(resource.get("uri_template")) in safe_resources
-    ]
+    if safe_resources:
+        resources = [
+            resource
+            for resource in resources
+            if isinstance(resource, dict)
+            and _safe_resource_match(safe_resources, str(resource.get("uri_template")))
+        ]
+    else:
+        resources = []
     server = dict(capabilities.get("server", {}))
     server["http_access"] = {
         "safe_tools_only": safe_tools is not None,

--- a/tests/mcp/test_resource_api.py
+++ b/tests/mcp/test_resource_api.py
@@ -1,0 +1,157 @@
+"""MCP resource-API contract tests (wave-2 MED-02).
+
+Pins that:
+- ``gnn.mcp.list_available_resources`` returns the real resource list
+  (it previously aliased ``get_available_tools`` and returned the tool list);
+- HTTP capability listing and the resource read gate agree on the only
+  registered resource (`gnn://documentation/{doc_name}`) — listing a
+  concrete URI exposes the read while keeping capabilities honest;
+- `npx_inspector.get_resource` no longer sends a URI as a JSON-RPC method.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.mcp
+
+import gnn.mcp as mcp_pkg
+from gnn.mcp.server_http import (
+    get_http_capabilities,
+    get_safe_http_resource_uris,
+    is_safe_http_resource,
+)
+
+
+class TestRealResourceLister:
+    """list_available_resources returns resources, not tools."""
+
+    @pytest.mark.unit
+    def test_returns_resource_dicts_not_tool_dicts(self) -> None:
+        from gnn.mcp import initialize
+
+        initialize(halt_on_missing_sdk=False, force_proceed_flag=True)
+        resources = mcp_pkg.list_available_resources()
+        assert isinstance(resources, list)
+        assert resources, "the registry must have at least one resource"
+        for resource in resources:
+            assert "uri" in resource  # not a tool's "name" key
+
+    @pytest.mark.unit
+    def test_exposes_gnn_documentation_template(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from gnn.mcp import initialize
+
+        initialize(halt_on_missing_sdk=False, force_proceed_flag=True)
+        from gnn.mcp import mcp_instance
+
+        # Wait for the documentation resource to register (discovery may
+        # still be in flight after initialize returns).
+        import time
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if "gnn://documentation/{doc_name}" in mcp_instance.resources:
+                break
+            time.sleep(0.1)
+        resources = mcp_pkg.list_available_resources()
+        templates = {r.get("uri") for r in resources if isinstance(r, dict)}
+        assert "gnn://documentation/{doc_name}" in templates
+
+
+class TestHTTPResourceGateAgreesWithCapabilities:
+    """Listing a concrete URI must expose the read AND show the resource."""
+
+    @pytest.mark.unit
+    def test_concrete_uri_exposes_read_while_capabilities_stay_honest(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from gnn.mcp import initialize
+
+        initialize(halt_on_missing_sdk=False, force_proceed_flag=True)
+        from gnn.mcp import mcp_instance
+
+        import time
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if "gnn://documentation/{doc_name}" in mcp_instance.resources:
+                break
+            time.sleep(0.1)
+        monkeypatch.setenv("GNN_MCP_SAFE_RESOURCES", "gnn://documentation/grammar")
+        assert is_safe_http_resource("gnn://documentation/grammar") is True
+        assert is_safe_http_resource("gnn://documentation/missing") is False
+
+        capabilities = get_http_capabilities()
+        templates = {
+            r["uri_template"] for r in capabilities["resources"] if isinstance(r, dict)
+        }
+        assert "gnn://documentation/{doc_name}" in templates
+
+    @pytest.mark.unit
+    def test_template_uri_exposes_all_concrete_reads(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from gnn.mcp import initialize
+
+        initialize(halt_on_missing_sdk=False, force_proceed_flag=True)
+        from gnn.mcp import mcp_instance
+
+        import time
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if "gnn://documentation/{doc_name}" in mcp_instance.resources:
+                break
+            time.sleep(0.1)
+        monkeypatch.setenv("GNN_MCP_SAFE_RESOURCES", "gnn://documentation/{doc_name}")
+        for doc in ("grammar", "file_structure", "punctuation", "schema_json"):
+            assert is_safe_http_resource(f"gnn://documentation/{doc}") is True
+        assert is_safe_http_resource("gnn://other/thing") is False
+
+    @pytest.mark.unit
+    def test_default_denies_everything(self) -> None:
+        assert is_safe_http_resource("gnn://documentation/grammar") is False
+
+
+class TestNpxInspectorResourceRead:
+    """The inspector routes reads through the real method, not as a guess."""
+
+    @pytest.mark.unit
+    def test_get_resource_uses_mcp_resource_get(self) -> None:
+        from gnn.mcp.npx_inspector import StdioMCPClient
+
+        captured: dict[str, Any] = {}
+
+        def fake_send_request(method: str, params: Any = None) -> dict[str, Any]:
+            captured["method"] = method
+            captured["params"] = params
+            return {"ok": True}
+
+        # Bypass __init__ (which spawns a process) and patch the send path.
+        client = StdioMCPClient.__new__(StdioMCPClient)
+        client._send_request = fake_send_request  # type: ignore[method-assign]
+        client.get_resource("gnn://documentation/grammar")
+        assert captured["method"] == "mcp.resource.get"
+        assert captured["params"] == {"uri": "gnn://documentation/grammar"}
+
+
+class TestToolCountGateStaysGreen:
+    """Adding resources and re-exporting the lister must not move the tool count."""
+
+    @pytest.mark.unit
+    def test_documented_count_matches_audit(self) -> None:
+        audit = json.loads(
+            __import__("pathlib")
+            .Path(__file__)
+            .resolve()
+            .parents[2]
+            .joinpath("src/gnn/mcp/audit_report.json")
+            .read_text(encoding="utf-8")
+        )
+        assert audit["tools_total"] >= 140
+        assert audit.get("schema_checks_ok", 0) == audit["tools_total"]


### PR DESCRIPTION
Wave-2 MED-02 (scoped in #62):

- gnn.mcp.list_available_resources returns the real resource list (MCP.list_available_resources) instead of aliasing get_available_tools (which returned the tool list mislabelled as resources)
- HTTP resource gate (is_safe_http_resource) and capability filter (get_http_capabilities) now agree on templated resources: listing a concrete URI (gnn://documentation/grammar) exposes its read AND shows the template in capabilities; listing the template itself exposes all concrete reads; before, the capability filter matched the template string while the read gate matched concrete URIs — no config exposed both
- AGENTS.md MCPResource fields corrected to match models.py; README.md error-code table corrected (-32601 for missing resources, not -32002; -32008 added for tool timeout); docs/mcp/README.md module tree corrected (src/gnn/mcp/ not src/mcp/; gui/mcp.py added)
- npx_inspector.get_resource routes through mcp.resource.get (was a guess that sent the URI as a JSON-RPC method — could never retrieve a resource)

Pinned by tests/mcp/test_resource_api.py (7 tests). 712 tests/mcp + tests/execute green; mypy 0; ruff clean; bench green (952 checks); doc-path gate clean.