### PR TITLE
test(validator): GNNValidator coverage (stochasticity, level-rank, construction, validate_file levels)

### DIFF
--- a/tests/gnn/test_gnn_validator.py
+++ b/tests/gnn/test_gnn_validator.py
@@ -1,0 +1,183 @@
+"""Unit tests for ``gnn.schema_validator.validator.GNNValidator``.
+
+The validator measured 48.7% in the verification harness: the level-rank
+mapping, constructor wiring, stochasticity checker, and the level-gated
+``validate_file`` paths (binary files, markdown structure gate) were
+unpinned. Tests build the valid document from ``REQUIRED_SECTIONS`` itself
+so they track the section contract rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from gnn.schema_validator.validator import GNNValidator
+from gnn.schemas.section_contract import REQUIRED_SECTIONS
+from gnn.types import ValidationLevel
+
+REQUIRED_CONTENT = {
+    "GNNSection": "Generalized Notation Notation",
+    "GNNVersionAndFlags": "GNNv1",
+    "ModelName": "TestModel",
+    "ModelAnnotation": "A test model.",
+    "StateSpaceBlock": "s_f[2,2] # state factor\n",
+    "Connections": "s_f > s_f\n",
+    "InitialParameterization": "A = uniform\n",
+    "Time": "Dynamic\nHorizon=5\n",
+    "Footer": "End of model.",
+}
+
+
+def _valid_document() -> str:
+    parts = []
+    for section in REQUIRED_SECTIONS:
+        parts.append(f"## {section}\n{REQUIRED_CONTENT[section]}\n")
+    return "\n".join(parts)
+
+
+def _write_doc(tmp_path: Path, content: str, name: str = "model.md") -> Path:
+    target = tmp_path / name
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+class TestCheckStochasticity:
+    def setup_method(self) -> None:
+        self.validator = GNNValidator()
+
+    def test_2d_stochastic_matrix_is_valid(self) -> None:
+        assert self.validator._check_stochasticity([[0.5, 0.5], [0.25, 0.75]]) is True
+
+    def test_2d_non_stochastic_row_is_rejected(self) -> None:
+        assert self.validator._check_stochasticity([[0.5, 0.6], [0.5, 0.5]]) is False
+
+    def test_1d_vector_branches(self) -> None:
+        assert self.validator._check_stochasticity([0.3, 0.7]) is True
+        assert self.validator._check_stochasticity([0.3, 0.8]) is False
+
+    def test_uncheckable_input_is_conservatively_valid(self) -> None:
+        # Empty and non-numeric inputs cannot be checked; the contract is to
+        # assume valid rather than fail the model.
+        # Empty and None inputs cannot be checked; the contract is to
+        # assume valid rather than fail the model. A non-empty non-numeric
+        # 1D vector sums to 0 (not 1), so it is genuinely rejected.
+        assert self.validator._check_stochasticity([]) is True
+        assert self.validator._check_stochasticity(["a", "b"]) is False
+        assert self.validator._check_stochasticity(None) is True
+
+    def test_tolerance_accepts_near_stochastic(self) -> None:
+        assert self.validator._check_stochasticity([[0.5, 0.5000005]]) is True
+
+
+class TestLevelRank:
+    def setup_method(self) -> None:
+        self.validator = GNNValidator()
+
+    @pytest.mark.parametrize(
+        "level,expected",
+        [
+            (ValidationLevel.BASIC, 10),
+            (ValidationLevel.STANDARD, 20),
+            (ValidationLevel.STRICT, 30),
+            (ValidationLevel.RESEARCH, 40),
+            (ValidationLevel.ROUND_TRIP, 50),
+        ],
+    )
+    def test_enum_ranks(self, level: ValidationLevel, expected: int) -> None:
+        assert self.validator._level_rank(level) == expected
+
+    def test_string_level_is_resolved(self) -> None:
+        assert self.validator._level_rank("strict") == 30
+
+    def test_unknown_level_ranks_zero_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="gnn.schema_validator.validator"):
+            assert self.validator._level_rank("nonsense") == 0
+        assert any("Unknown validation level" in r.message for r in caplog.records)
+
+
+class TestValidatorConstruction:
+    def test_default_schema_path(self) -> None:
+        validator = GNNValidator()
+
+        assert validator.schema_path.name == "json.json"
+        assert validator.schema_path.parent.name == "schemas"
+        assert validator.enable_round_trip_testing is False
+        assert validator.validation_level == ValidationLevel.STANDARD
+
+    def test_cross_validation_disabled_leaves_no_cross_validator(self) -> None:
+        validator = GNNValidator(enable_cross_validation=False)
+
+        assert validator.cross_validator is None
+
+    def test_cross_validation_enabled_wires_cross_validator(self) -> None:
+        validator = GNNValidator(enable_cross_validation=True)
+
+        assert validator.cross_validator is not None
+
+
+class TestValidateFileLevels:
+    def test_valid_document_passes_at_basic_level(self, tmp_path: Path) -> None:
+        validator = GNNValidator(validation_level=ValidationLevel.BASIC)
+        target = _write_doc(tmp_path, _valid_document())
+
+        result = validator.validate_file(target)
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert result.format_tested == "markdown"
+        assert result.metadata.get("parsed_successfully") is True
+
+    def test_missing_required_section_is_flagged(self, tmp_path: Path) -> None:
+        content = _valid_document().replace("## ModelName\nTestModel\n\n", "")
+        validator = GNNValidator(validation_level=ValidationLevel.BASIC)
+        target = _write_doc(tmp_path, content)
+
+        result = validator.validate_file(target)
+
+        assert result.is_valid is False
+        assert any(
+            "Required section missing: ModelName" in error for error in result.errors
+        )
+
+    def test_research_level_runs_on_valid_document(self, tmp_path: Path) -> None:
+        validator = GNNValidator(
+            validation_level=ValidationLevel.RESEARCH, enable_cross_validation=False
+        )
+        target = _write_doc(tmp_path, _valid_document())
+
+        result = validator.validate_file(target)
+
+        # The research-level pipeline must complete without raising; validity
+        # reflects the recorded errors, whatever the deeper gates find.
+        assert result.validation_level == ValidationLevel.RESEARCH
+        assert result.is_valid == (len(result.errors) == 0)
+        assert "validation_time" in result.performance_metrics
+
+    def test_unknown_format_file_still_validates_as_text(self, tmp_path: Path) -> None:
+        validator = GNNValidator(validation_level=ValidationLevel.BASIC)
+        target = _write_doc(tmp_path, _valid_document(), name="model.weird")
+
+        result = validator.validate_file(target)
+
+        assert result.format_tested == "unknown"
+        assert result.is_valid is True
+
+    def test_pkl_extension_treated_as_parseable_text_format(
+        self, tmp_path: Path
+    ) -> None:
+        # The .pkl extension routes to the text-parse path (not the binary
+        # branch): non-pickle garbage is parsed leniently, so the validator
+        # reports the format and a parsed_successfully flag rather than raising.
+        validator = GNNValidator()
+        target = tmp_path / "model.pkl"
+        target.write_bytes(b"definitely not a pickle payload")
+
+        result = validator.validate_file(target)
+
+        assert result.format_tested == "pkl"
+        assert "parsed_successfully" in result.metadata


### PR DESCRIPTION
## Wave 2, PR 5 — GNNValidator coverage (stochasticity, level-rank, construction, validate_file levels)

Session: `deep/gnn-tests-ci` (deep horizon wave 2, tests + CI). Follows merged PRs #64/#72/#77. Additions only. Final iteration at the 12-run cap.

### Changes

- **`tests/gnn/test_gnn_validator.py` (+20 tests).** `gnn.schema_validator.validator.GNNValidator` measured 48.7% of 388 statements in the verification harness. Pinned: `_check_stochasticity` (2D/1D valid + reject, empty/None conservative, non-numeric 1D rejected, tolerance band), `_level_rank` (all 5 `ValidationLevel` enum ranks + string resolution + unknown→0 warning), constructor (default schema path, cross-validation on/off wiring), and `validate_file` levels (BASIC valid doc passes, missing required section flagged, RESEARCH completes with perf metrics, unknown extension treated as text, `.pkl` routes to the parseable text path). The valid document is built from `REQUIRED_SECTIONS` so the tests track the section contract rather than duplicating it. Placed in the existing `tests/gnn/` dir to avoid tripping the capability-contract directory-count gate.

### Verification

- Targeted: 20/20 green; ruff check + format clean.
- Full harness (run #12): `coverage_percent=63.04`, `tests_passed=4498`, `tests_failed=0`, `tests_skipped=7`. Largest single-iteration coverage jump of the continuation (+1.12pp).
- Session trajectory: 60.12 → 61.14 → 61.72 → 61.84 → 61.92 → **63.04** (+155 tests since baseline, +2.92pp).
