### PR TITLE
perf(export): validate_export_format uses O(1) lookup instead of dict copy

### DIFF
--- a/src/gnn/export/__init__.py
+++ b/src/gnn/export/__init__.py
@@ -31,6 +31,7 @@ from .processor import (
 from .registry import (
     get_export_registry,
     get_format_categories,
+    is_supported_format,
 )
 from .utils import get_module_info
 
@@ -84,7 +85,7 @@ def get_supported_formats_dict() -> dict:
 
 def validate_export_format(format_name: str) -> bool:
     """Return True if the format is supported, False otherwise."""
-    return format_name in get_export_registry()
+    return is_supported_format(format_name)
 
 
 class Exporter:


### PR DESCRIPTION
validate_export_format called `format_name in get_export_registry()` which creates a dict copy (23 key-value pairs) on every call. The bench calls this 40x per rep through the MCP validate_export_format tool, so 40 dict copies per rep were eliminated. Now uses `is_supported_format` which does `format_name in _REGISTRY` (O(1) dict key lookup, no copy).

Correct: export tests green, 952 determinism checks. Within bench noise (envelope phase dominates).