### PR TITLE
deep-w2 segment 2 batch 4: framework walker tolerance + estimator facade tests

### DIFF
--- a/tests/analysis/test_framework_walkers_tolerance.py
+++ b/tests/analysis/test_framework_walkers_tolerance.py
@@ -1,0 +1,93 @@
+"""Tolerance contracts for the per-framework ``generate_analysis_from_logs`` walkers.
+
+The analyzers walk Step-12 output trees and must degrade silently (warn +
+continue) on malformed or missing inputs, and must always return a list.
+These tests exercise the walkers without depending on matplotlib internals.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gnn.analysis.activeinference_jl.analyzer import (
+    generate_analysis_from_logs as generate_aijl,
+)
+from gnn.analysis.discopy.analyzer import (
+    generate_analysis_from_logs as generate_discopy,
+)
+from gnn.analysis.jax.analyzer import (
+    generate_analysis_from_logs as generate_jax,
+)
+
+
+def test_discopy_walker_empty_execution_dir_returns_empty(tmp_path: Path) -> None:
+    out = tmp_path / "viz"
+
+    assert generate_discopy(tmp_path, out, verbose=False) == []
+
+
+def test_discopy_walker_tolerates_malformed_circuit_json(tmp_path: Path) -> None:
+    sim_data = tmp_path / "model" / "discopy" / "simulation_data"
+    sim_data.mkdir(parents=True)
+    (sim_data / "circuit_analysis.json").write_text("{broken", encoding="utf-8")
+    out = tmp_path / "viz"
+
+    result = generate_discopy(tmp_path, out, verbose=False)
+
+    assert result == []
+
+
+def test_aijl_walker_empty_execution_dir_creates_output_dir(tmp_path: Path) -> None:
+    out = tmp_path / "viz" / "aijl"
+
+    result = generate_aijl(tmp_path, out, verbose=False)
+
+    assert result == []
+    assert out.is_dir()
+
+
+def test_aijl_walker_tolerates_malformed_results_json(tmp_path: Path) -> None:
+    sim_data = tmp_path / "model" / "activeinference_jl" / "simulation_data"
+    sim_data.mkdir(parents=True)
+    (sim_data / "run_simulation_results.json").write_text("{broken", encoding="utf-8")
+    out = tmp_path / "viz"
+
+    result = generate_aijl(tmp_path, out, verbose=False)
+
+    assert result == []
+
+
+def test_jax_walker_empty_execution_dir_returns_empty(tmp_path: Path) -> None:
+    out = tmp_path / "viz"
+
+    assert generate_jax(tmp_path, out, verbose=False) == []
+
+
+def test_jax_walker_tolerates_malformed_results_json(tmp_path: Path) -> None:
+    logs = tmp_path / "model" / "jax" / "execution_logs"
+    logs.mkdir(parents=True)
+    (logs / "run_results.json").write_text("{broken", encoding="utf-8")
+    out = tmp_path / "viz"
+
+    result = generate_jax(tmp_path, out, verbose=False)
+
+    assert result == []
+
+
+def test_discopy_walker_skips_dirs_without_simulation_data(tmp_path: Path) -> None:
+    (tmp_path / "model" / "discopy").mkdir(parents=True)
+    out = tmp_path / "viz"
+
+    assert generate_discopy(tmp_path, out, verbose=False) == []
+
+
+def test_json_payload_that_is_not_a_dict_is_tolerated(tmp_path: Path) -> None:
+    """A valid-JSON but non-object payload (e.g. a bare list) must not crash
+    the walker — the framework extraction contract is dict-shaped."""
+    sim_data = tmp_path / "model" / "discopy" / "simulation_data"
+    sim_data.mkdir(parents=True)
+    (sim_data / "circuit_analysis.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    out = tmp_path / "viz"
+
+    assert generate_discopy(tmp_path, out, verbose=False) == []

--- a/tests/type_checker/test_resource_estimator_facade.py
+++ b/tests/type_checker/test_resource_estimator_facade.py
@@ -1,0 +1,63 @@
+"""Pins for ``type_checker.resource_estimator`` (previously 27%)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+import gnn.type_checker.resource_estimator as resource_estimator
+from gnn.type_checker.estimation.estimator import GNNResourceEstimator
+
+_SPEC = """## GNNSection
+ActInfPOMDP
+
+## ModelName
+EstimatorProbe
+
+## StateSpaceBlock
+s[3,1,type=float]
+o[3,1,type=int]
+
+## Connections
+s-s
+s-o
+
+## Footer
+EstimatorProbe
+"""
+
+
+def test_facade_exposes_the_canonical_estimator() -> None:
+    assert resource_estimator.__all__ == ["GNNResourceEstimator"]
+    assert resource_estimator.GNNResourceEstimator is GNNResourceEstimator
+
+
+def test_main_estimates_single_file_and_prints_report(
+    tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = tmp_path / "probe.gnn"
+    spec.write_text(_SPEC, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["resource_estimator", str(spec)])
+
+    exit_code = resource_estimator.main()
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "EstimatorProbe" in captured.out or "probe" in captured.out
+
+
+def test_main_estimates_directory_recursive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "specs"
+    target.mkdir()
+    (target / "probe.gnn").write_text(_SPEC, encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", ["resource_estimator", str(target), "--recursive"]
+    )
+
+    exit_code = resource_estimator.main()
+
+    assert exit_code == 0

--- a/tests/type_checker/test_resource_estimator_facade.py
+++ b/tests/type_checker/test_resource_estimator_facade.py
@@ -39,7 +39,9 @@ def test_main_estimates_single_file_and_prints_report(
 ) -> None:
     spec = tmp_path / "probe.gnn"
     spec.write_text(_SPEC, encoding="utf-8")
-    monkeypatch.setattr(sys, "argv", ["resource_estimator", str(spec)])
+    monkeypatch.setattr(
+        sys, "argv", ["resource_estimator", str(spec), "-o", str(tmp_path)]
+    )
 
     exit_code = resource_estimator.main()
 
@@ -55,7 +57,9 @@ def test_main_estimates_directory_recursive(
     target.mkdir()
     (target / "probe.gnn").write_text(_SPEC, encoding="utf-8")
     monkeypatch.setattr(
-        sys, "argv", ["resource_estimator", str(target), "--recursive"]
+        sys,
+        "argv",
+        ["resource_estimator", str(target), "--recursive", "-o", str(tmp_path)],
     )
 
     exit_code = resource_estimator.main()


### PR DESCRIPTION
Coverage segment batch 4 (continuation of PR #83): 11 more contract tests.

- discopy/activeinference_jl/jax generate_analysis_from_logs walkers: silent degradation on empty dirs, malformed JSON, non-dict payloads, and missing simulation_data (always return a list).
- type_checker.resource_estimator facade: canonical estimator identity, single-file and recursive-directory main() paths (reports directed to tmp_path — no repo artifacts).

Deterministic harness: coverage 61 -> 62, tests 885 -> 896, quality_violations stays 0. Local gates: ruff check/format clean, mypy src/gnn clean.