### PR TITLE
deep-w2 segment 2 batch 7: Step-16 scope filters, DisCoPy pipeline, PyMDP visualizer contracts

### DIFF
--- a/tests/analysis/test_discopy_analyzer_viz.py
+++ b/tests/analysis/test_discopy_analyzer_viz.py
@@ -1,0 +1,63 @@
+"""Pins for the DisCoPy analyzer visualization pipeline (previously 12%)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gnn.analysis.discopy.analyzer import (
+    create_discopy_visualizations,
+    generate_analysis_from_logs,
+)
+
+_CIRCUIT_PAYLOAD = {
+    "components": ["box_a", "box_b", "box_c"],
+    "analysis": {"num_components": 3, "loop_domain": "discrete"},
+    "parameters": {"num_states": 2, "num_observations": 2},
+}
+
+
+def test_create_discopy_visualizations_renders_files(tmp_path: Path) -> None:
+    generated = create_discopy_visualizations(
+        dict(_CIRCUIT_PAYLOAD), tmp_path, "CircuitModel"
+    )
+
+    assert generated, "expected at least one rendered visualization"
+    for path in generated:
+        assert Path(path).exists()
+        assert Path(path).suffix in {".png", ".svg", ".html"}
+
+
+def test_create_discopy_visualizations_skips_empty_circuits(tmp_path: Path) -> None:
+    generated = create_discopy_visualizations(
+        {"components": [], "num_components": 0}, tmp_path, "EmptyModel"
+    )
+
+    assert generated == []
+
+
+def test_walker_processes_circuit_analysis_files(tmp_path: Path) -> None:
+    sim_data = tmp_path / "CircuitModel" / "discopy" / "simulation_data"
+    sim_data.mkdir(parents=True)
+    (sim_data / "circuit_analysis.json").write_text(
+        json.dumps(_CIRCUIT_PAYLOAD), encoding="utf-8"
+    )
+    out = tmp_path / "viz"
+
+    generated = generate_analysis_from_logs(tmp_path, out, verbose=False)
+
+    assert generated
+    assert out.is_dir()
+
+
+def test_walker_routes_source_file_metadata(tmp_path: Path) -> None:
+    sim_data = tmp_path / "MetaModel" / "discopy" / "simulation_data"
+    sim_data.mkdir(parents=True)
+    (sim_data / "circuit_info.json").write_text(
+        json.dumps(_CIRCUIT_PAYLOAD), encoding="utf-8"
+    )
+    out = tmp_path / "viz"
+
+    generated = generate_analysis_from_logs(tmp_path, out, verbose=False)
+
+    assert generated

--- a/tests/analysis/test_processor_scope_filters.py
+++ b/tests/analysis/test_processor_scope_filters.py
@@ -1,0 +1,168 @@
+"""Pins for the Step-16 scope-filter helpers (``analysis.processor``)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from gnn.analysis.processor import (
+    _filter_execution_summary,
+    _normalize_generate_animations,
+    _scope_from_execution_summary,
+)
+
+
+def _logger() -> logging.Logger:
+    return logging.getLogger("w2probe-processor")
+
+
+def _summary() -> dict:
+    return {
+        "requested_frameworks": ["PyMDP", "JAX"],
+        "execution_details": [
+            {
+                "framework": "pymdp",
+                "success": True,
+                "model_name": "Simple MDP Agent",
+                "structured_result_file": "out/pymdp/results.json",
+            },
+            {
+                "framework": "discopy",
+                "success": False,
+                "skipped": True,
+                "model_name": "Circuit Model",
+            },
+        ],
+        "framework_status": {"pymdp": "ok", "discopy": "skipped"},
+    }
+
+
+# --- _normalize_generate_animations ------------------------------------------
+
+
+def test_canonical_true_and_false_are_returned() -> None:
+    assert _normalize_generate_animations({"generate_animations": True}, _logger()) is True
+    assert (
+        _normalize_generate_animations({"generate_animations": False}, _logger()) is False
+    )
+
+
+def test_string_flags_are_coerced() -> None:
+    assert (
+        _normalize_generate_animations({"generate_animations": "false"}, _logger())
+        is False
+    )
+    assert _normalize_generate_animations({"generate_animations": 1}, _logger()) is True
+
+
+def test_conflicting_legacy_flag_raises() -> None:
+    with pytest.raises(ValueError, match="Ambiguous animation flags"):
+        _normalize_generate_animations(
+            {"generate_animations": True, "no_animations": True}, _logger()
+        )
+
+
+def test_legacy_only_flag_is_inverted() -> None:
+    assert _normalize_generate_animations({"no_animations": True}, _logger()) is False
+
+
+def test_default_is_animations_enabled() -> None:
+    assert _normalize_generate_animations({}, _logger()) is True
+
+
+def test_requested_frameworks_normalize_and_win_when_present() -> None:
+    # Requested frameworks seed the scope; frameworks with a successful
+    # result pointer narrow it (pymdp succeeded, discopy was skipped).
+    scope = _scope_from_execution_summary(_summary())
+
+    assert scope["frameworks"] == {"pymdp"}
+    assert scope["models"] is not None and "Simple MDP Agent" in scope["models"]
+
+
+def test_requested_frameworks_survive_when_no_details_succeed() -> None:
+    summary = {
+        "requested_frameworks": ["PyMDP", "JAX"],
+        "execution_details": [
+            {"framework": "pymdp", "success": False, "skipped": True}
+        ],
+    }
+
+    scope = _scope_from_execution_summary(summary)
+
+    # With no successful result pointers, the requested list stands.
+    assert scope["frameworks"] == {"pymdp", "jax"}
+
+
+# --- _filter_execution_summary -----------------------------------------------
+
+
+
+
+def test_successful_details_restrict_frameworks() -> None:
+    summary = {
+        "execution_details": [
+            {
+                "framework": "pymdp",
+                "success": True,
+                "structured_result_file": "results.json",
+            },
+            {"framework": "jax", "success": False},
+        ]
+    }
+
+    scope = _scope_from_execution_summary(summary)
+
+    # Only frameworks with successful result pointers remain in scope.
+    assert scope["frameworks"] == {"pymdp"}
+
+
+def test_empty_summary_yields_none_scope() -> None:
+    scope = _scope_from_execution_summary({})
+
+    assert scope == {"frameworks": None, "models": None}
+
+
+def test_target_model_names_seed_the_model_scope() -> None:
+    scope = _scope_from_execution_summary({}, target_model_names={"seeded_model"})
+
+    assert scope["models"] == {"seeded_model"}
+    assert scope["frameworks"] is None
+
+
+def test_framework_directory_in_script_path_seeds_model() -> None:
+    summary = {
+        "execution_details": [
+            {
+                "framework": "pymdp",
+                "success": True,
+                "output_file": "x",
+                "script_path": "output/12_execute_output/actinf_pomdp_agent/pymdp/run.py",
+            }
+        ]
+    }
+
+    scope = _scope_from_execution_summary(summary)
+
+    assert "actinf_pomdp_agent" in (scope["models"] or set())
+
+
+# --- _filter_execution_summary ------------------------------------------------
+
+
+def test_filter_without_allowlist_returns_original_object() -> None:
+    summary = _summary()
+
+    assert _filter_execution_summary(summary, None) is summary
+
+
+def test_filter_keeps_only_allowed_frameworks() -> None:
+    summary = _summary()
+
+    filtered = _filter_execution_summary(summary, {"pymdp"})
+
+    details = filtered["execution_details"]
+    assert [d["framework"] for d in details] == ["pymdp"]
+    assert set(filtered["framework_status"]) == {"pymdp"}
+    # The input summary is deep-copied, not mutated.
+    assert len(summary["execution_details"]) == 2

--- a/tests/analysis/test_pymdp_visualizer.py
+++ b/tests/analysis/test_pymdp_visualizer.py
@@ -1,0 +1,53 @@
+"""Pins for ``analysis/pymdp/visualizer`` (previously 10% coverage)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gnn.analysis.pymdp.visualizer import (
+    PyMDPVisualizer,
+    create_visualizer,
+    save_all_visualizations,
+)
+
+
+def test_constructor_normalizes_positional_output_dir(tmp_path: Path) -> None:
+    visualizer = PyMDPVisualizer(tmp_path)
+
+    assert visualizer.save_dir == Path(tmp_path)
+    assert visualizer.show_plots is False or visualizer.show_plots is True
+
+
+def test_constructor_prefers_explicit_save_dir(tmp_path: Path) -> None:
+    visualizer = PyMDPVisualizer(save_dir=tmp_path / "custom", show_plots=False)
+
+    assert visualizer.save_dir == Path(tmp_path / "custom")
+
+
+def test_factory_applies_config(tmp_path: Path) -> None:
+    visualizer = create_visualizer(
+        {"grid_size": 4, "save_dir": str(tmp_path), "figsize": (6, 6)}
+    )
+
+    assert visualizer.grid_size == 4
+    assert visualizer.save_dir == Path(str(tmp_path))
+    assert visualizer.figsize == (6, 6)
+
+
+def test_save_all_visualizations_renders_synthetic_results(tmp_path: Path) -> None:
+    results = {
+        "states": [0, 1, 2, 1, 0],
+        "num_states": 3,
+        "beliefs": [[0.8, 0.2], [0.3, 0.7]],
+        "observations": [0, 1, 1],
+        "metrics": {
+            "vfe_history": [1.2, 0.9, 0.7],
+            "efe_history": [2.0, 1.8, 1.5],
+        },
+    }
+
+    saved = save_all_visualizations(results, tmp_path)
+
+    assert saved, "expected rendered visualizations for a full results payload"
+    for path in saved.values():
+        assert path.exists()


### PR DESCRIPTION
Coverage segment batch 7 (continuation of PRs #83/#88/#90/#91): 21 more contract tests.

- analysis/processor (35%->): animation-flag normalization (canonical vs legacy no_animations, conflict raising, string coercion), execution-scope derivation (requested-framework seeding, successful-pointer narrowing, script-path model discovery, empty-summary None scope), deep-copy summary filtering.
- analysis/discopy (12%->): circuit visualizations rendered from synthetic payloads through the walker (both circuit_info.json and circuit_analysis.json routes).
- analysis/pymdp/visualizer (10%->): constructor normalization (positional output-dir, save_dir preference, config dict), factory, save_all_visualizations over a synthetic results payload.

Deterministic harness: coverage 63 -> 65, tests 926 -> 947, quality_violations stays 0.