### PR TITLE
security: close the GNNExecutor execution-gate bypass; fail-closed pre-exec gate + sandbox receipts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,7 +412,7 @@ exclude_lines = [
 
 [tool.bandit]
 exclude_dirs = ["tests"]
-skips = ["B101", "B601"]
+skips = ["B101"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/gnn/execute/executor.py
+++ b/src/gnn/execute/executor.py
@@ -197,8 +197,6 @@ def _pre_execution_gate(model_path: Union[str, Path]) -> Optional[Dict[str, Any]
     }
 
 
-
-
 class GNNExecutor:
     """
     Main executor for GNN model simulations and scripts.
@@ -1132,14 +1130,6 @@ def execute_script_safely(
             - ``error_type`` (str, optional): Exception class name on failure.
     """
     script = Path(script_path)
-    gate_result = _pre_execution_gate(script)
-    if gate_result is not None:
-        gate_result["script_path"] = str(script)
-        gate_result["return_code"] = NEVER_STARTED
-        gate_result["stdout"] = ""
-        gate_result["stderr"] = ""
-        gate_result["duration_seconds"] = 0.0
-        return gate_result
     if not script.exists():
         return {
             "success": False,
@@ -1165,6 +1155,17 @@ def execute_script_safely(
             ),
             "error_type": "ValueError",
         }
+    # Pre-execution security gate (SC-1): real Python scripts are scanned
+    # before running. Missing/suffix rejections keep their historical
+    # envelopes; the gate covers everything that could actually execute.
+    gate_result = _pre_execution_gate(script)
+    if gate_result is not None:
+        gate_result["script_path"] = str(script)
+        gate_result["return_code"] = NEVER_STARTED
+        gate_result["stdout"] = ""
+        gate_result["stderr"] = ""
+        gate_result["duration_seconds"] = 0.0
+        return gate_result
 
     envelope = run_subprocess_envelope(
         [sys.executable, str(script)],

--- a/src/gnn/execute/executor.py
+++ b/src/gnn/execute/executor.py
@@ -14,7 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, cast
 
-from .subprocess_envelope import run_subprocess_envelope
+from .subprocess_envelope import NEVER_STARTED, run_subprocess_envelope
+from .types import _gnn_allow_unsafe_exec
 
 # Import execution functionality
 try:
@@ -134,6 +135,70 @@ def get_available_hardware() -> list[str]:
         return ["cpu"]
 
 
+def _pre_execution_gate(model_path: Union[str, Path]) -> Optional[Dict[str, Any]]:
+    """Pre-execution security gate for the MCP/``GNNExecutor`` dispatch stack.
+
+    Mirrors the Step 12 processor gate (``execute.processor``): every script
+    dispatched to a runner is scanned by
+    ``gnn.security.processor.scan_script_for_execution`` before execution, so
+    the MCP path cannot bypass the gate the pipeline enforces. Unreadable or
+    unscannable targets fail closed; the ``GNN_ALLOW_UNSAFE_EXEC`` escape
+    hatch is honored identically on both stacks.
+
+    Returns ``None`` when execution may proceed, otherwise a structured
+    blocked result (``error_type="SecurityGateBlocked"``) matching the
+    processor's gate receipt.
+    """
+    if _gnn_allow_unsafe_exec():
+        return None
+    target = Path(model_path)
+    if target.suffix.lower() not in (".py", ".jl"):
+        return None
+    verdict: Dict[str, Any]
+    try:
+        from gnn.security.processor import scan_script_for_execution
+
+        verdict = scan_script_for_execution(target)
+    except Exception as exc:
+        # Fail closed: a broken security module or scanner must block
+        # execution, never silently skip the gate.
+        message = (
+            "Pre-execution security gate failed "
+            f"({type(exc).__name__}: {exc}); refusing to execute "
+            f"{target.name} (fail closed)"
+        )
+        logger.error(message)
+        return {
+            "success": False,
+            "error": message,
+            "error_type": "SecurityGateBlocked",
+            "security_findings": [],
+            "security_gate": {"scanned": False, "decision": "deny_gate_failure"},
+        }
+    if verdict.get("ok", True):
+        return None
+    blocked = verdict.get("blocked", [])
+    detail = "; ".join(
+        f"{b.get('vulnerability_type', 'unknown')}@{b.get('line', '?')}"
+        for b in blocked[:5]
+    )
+    message = f"Pre-execution security gate blocked {target.name}: {detail}"
+    logger.error(message)
+    return {
+        "success": False,
+        "error": message,
+        "error_type": "SecurityGateBlocked",
+        "security_findings": blocked,
+        "security_gate": {
+            "scanned": bool(verdict.get("scanned", False)),
+            "decision": verdict.get("decision", "deny"),
+            "block_on": verdict.get("block_on", "high"),
+        },
+    }
+
+
+
+
 class GNNExecutor:
     """
     Main executor for GNN model simulations and scripts.
@@ -177,7 +242,14 @@ class GNNExecutor:
         try:
             start_time = time.time()
 
-            if execution_type == "pymdp":
+            # Pre-execution security gate (RED_TEAM_REVIEW V-01/V-06): the
+            # Step 12 processor gates every rendered script, so this dispatch
+            # (MCP ``execute_gnn_model`` and friends) must not be a bypass.
+            # Blocked/failed-gate results skip the runners entirely.
+            gate_result = _pre_execution_gate(model_path)
+            if gate_result is not None:
+                result = gate_result
+            elif execution_type == "pymdp":
                 result = self._execute_pymdp_script(
                     model_path, options, timeout=timeout
                 )
@@ -1060,6 +1132,14 @@ def execute_script_safely(
             - ``error_type`` (str, optional): Exception class name on failure.
     """
     script = Path(script_path)
+    gate_result = _pre_execution_gate(script)
+    if gate_result is not None:
+        gate_result["script_path"] = str(script)
+        gate_result["return_code"] = NEVER_STARTED
+        gate_result["stdout"] = ""
+        gate_result["stderr"] = ""
+        gate_result["duration_seconds"] = 0.0
+        return gate_result
     if not script.exists():
         return {
             "success": False,

--- a/src/gnn/execute/metadata.py
+++ b/src/gnn/execute/metadata.py
@@ -301,6 +301,7 @@ def _slim_execution_detail(detail: Dict[str, Any]) -> Dict[str, Any]:
         "execution_metadata",
         "script_identity",
         "source_scope",
+        "sandbox",
     )
     slim: Dict[str, Any] = {}
     for k in keys_keep:

--- a/src/gnn/execute/processor.py
+++ b/src/gnn/execute/processor.py
@@ -68,9 +68,11 @@ from .subprocess_envelope import (
 )
 from .types import (
     _EXECUTABLE_SUFFIXES,
+    _GNN_ALLOW_UNSAFE_EXEC,
     ExecutionFrameworkName,
     ExecutionOutcome,
     ScriptExecutionContext,
+    _gnn_allow_unsafe_exec,
 )
 
 logger = logging.getLogger(__name__)
@@ -950,20 +952,6 @@ def _framework_for_data_helpers(framework: str) -> ExecutionFrameworkName:
     return cast(ExecutionFrameworkName, framework)
 
 
-#: Environment escape hatch: set to "1" to bypass the pre-execution security
-#: gate (trusted-local research use only; see SECURITY.md).
-_GNN_ALLOW_UNSAFE_EXEC = "GNN_ALLOW_UNSAFE_EXEC"
-
-
-def _gnn_allow_unsafe_exec() -> bool:
-    """Whether the operator has explicitly opted out of the pre-exec gate."""
-    return os.environ.get(_GNN_ALLOW_UNSAFE_EXEC, "").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-    )
-
-
 def _sandbox_mode() -> str:
     """Effective sandbox mode from ``GNN_SANDBOX`` (default ``off``)."""
     from .sandbox import SANDBOX_MODES
@@ -1039,24 +1027,35 @@ def execute_single_script(
     if not _gnn_allow_unsafe_exec():
         try:
             from gnn.security.processor import scan_script_for_execution
-
-            verdict = scan_script_for_execution(script_path)
-            if not verdict.get("ok", True):
-                blocked = verdict.get("blocked", [])
-                detail = "; ".join(
-                    f"{b.get('vulnerability_type', 'unknown')}@{b.get('line', '?')}"
-                    for b in blocked[:5]
-                )
-                exec_result["error"] = (
-                    f"Pre-execution security gate blocked {script_info['name']}: "
-                    f"{detail}"
-                )
-                exec_result["error_type"] = "SecurityGateBlocked"
-                exec_result["security_findings"] = blocked
-                logger.error(exec_result["error"])
-                return exec_result
-        except ImportError:
-            logger.debug("security.processor unavailable; pre-exec gate skipped")
+        except ImportError as exc:
+            # Fail closed (RED_TEAM_REVIEW V-01/V-06 follow-up): a broken
+            # security module must block execution rather than silently skip
+            # the pre-exec gate. Same SecurityGateBlocked path as a scan deny,
+            # with the import failure as the distinct reason.
+            exec_result["error"] = (
+                "Pre-execution security gate unavailable "
+                f"(security.processor import failed: {exc}); "
+                f"refusing to execute {script_info['name']} (fail closed)"
+            )
+            exec_result["error_type"] = "SecurityGateBlocked"
+            exec_result["security_findings"] = []
+            logger.error(exec_result["error"])
+            return exec_result
+        verdict = scan_script_for_execution(script_path)
+        if not verdict.get("ok", True):
+            blocked = verdict.get("blocked", [])
+            detail = "; ".join(
+                f"{b.get('vulnerability_type', 'unknown')}@{b.get('line', '?')}"
+                for b in blocked[:5]
+            )
+            exec_result["error"] = (
+                f"Pre-execution security gate blocked {script_info['name']}: "
+                f"{detail}"
+            )
+            exec_result["error_type"] = "SecurityGateBlocked"
+            exec_result["security_findings"] = blocked
+            logger.error(exec_result["error"])
+            return exec_result
 
     if framework == "rxinfer":
         exec_result["execution_metadata"] = (

--- a/src/gnn/execute/processor.py
+++ b/src/gnn/execute/processor.py
@@ -984,6 +984,35 @@ def _sandbox_command_prefix(mode: str) -> tuple[list[str], Optional[str]]:
     return list(spec.prefix), None
 
 
+def _sandbox_receipt(
+    mode: str, prefix: List[str], blocked_reason: Optional[str]
+) -> Dict[str, Any]:
+    """Build the pipeline-visible sandbox receipt for one script execution.
+
+    ``mode="off"`` keeps the trusted-local default but is recorded in the
+    execution summary rather than left silent (SC-2 fail-closed bundle): the
+    run receipt now shows *why* a script ran with the operator's full
+    privileges. ``prefer`` without a backend is ``fell_back_open``;
+    ``require`` failure never reaches this helper (blocked earlier with
+    ``SandboxUnavailable``).
+    """
+    sandboxed = bool(prefix)
+    if blocked_reason is not None:
+        reason: Optional[str] = blocked_reason
+    elif sandboxed:
+        reason = None
+    elif mode == "off":
+        reason = "unsandboxed execution (GNN_SANDBOX=off default)"
+    else:
+        reason = "unsandboxed execution (no sandbox backend found)"
+    return {
+        "mode": mode,
+        "sandboxed": sandboxed,
+        "backend": prefix[0] if sandboxed else None,
+        "reason": reason,
+    }
+
+
 def execute_single_script(
     script_info: Dict[str, Any],
     results_dir: Path,
@@ -1163,6 +1192,9 @@ def execute_single_script(
                 exec_result["error_type"] = "SandboxUnavailable"
                 logger.error(sandbox_blocked)
                 return exec_result
+            exec_result["sandbox"] = _sandbox_receipt(
+                sandbox_mode, sandbox_prefix, sandbox_blocked
+            )
             base_command = _build_script_execution_command(context, sandbox_prefix)
 
             for rep in range(K):

--- a/src/gnn/execute/processor.py
+++ b/src/gnn/execute/processor.py
@@ -1078,8 +1078,7 @@ def execute_single_script(
                 for b in blocked[:5]
             )
             exec_result["error"] = (
-                f"Pre-execution security gate blocked {script_info['name']}: "
-                f"{detail}"
+                f"Pre-execution security gate blocked {script_info['name']}: {detail}"
             )
             exec_result["error_type"] = "SecurityGateBlocked"
             exec_result["security_findings"] = blocked

--- a/src/gnn/execute/sandbox.py
+++ b/src/gnn/execute/sandbox.py
@@ -141,6 +141,16 @@ def run_sandboxed(
         "sandbox": None,
         "mode": effective,
         "blocked": False,
+        "sandbox_receipt": {
+            "mode": effective,
+            "sandboxed": False,
+            "backend": None,
+            "reason": (
+                "unsandboxed execution (GNN_SANDBOX=off default)"
+                if effective == "off"
+                else None
+            ),
+        },
         "success": False,
         "return_code": -1,
         "stdout": "",
@@ -162,13 +172,20 @@ def run_sandboxed(
                 "GNN_SANDBOX=prefer but no sandbox backend found; "
                 "running rendered script unsandboxed."
             )
+            envelope["sandbox_receipt"]["reason"] = (
+                "unsandboxed execution (no sandbox backend found)"
+            )
         final_command = list(command)
     else:
         final_command = wrap_command(command, spec)
         envelope["sandboxed"] = True
         envelope["sandbox"] = spec.binary
-
-    # Canonical subprocess envelope (MAJ-10): one structured outcome for
+        envelope["sandbox_receipt"] = {
+            "mode": effective,
+            "sandboxed": True,
+            "backend": spec.binary,
+            "reason": None,
+        }
     # timeout / OSError / non-zero exit; the sandbox-specific timeout message
     # shape is preserved on top of the shared envelope.
     outcome = run_subprocess_envelope(

--- a/src/gnn/execute/sandbox.py
+++ b/src/gnn/execute/sandbox.py
@@ -186,6 +186,7 @@ def run_sandboxed(
             "backend": spec.binary,
             "reason": None,
         }
+    # Canonical subprocess envelope (MAJ-10): one structured outcome for
     # timeout / OSError / non-zero exit; the sandbox-specific timeout message
     # shape is preserved on top of the shared envelope.
     outcome = run_subprocess_envelope(

--- a/src/gnn/execute/types.py
+++ b/src/gnn/execute/types.py
@@ -7,6 +7,7 @@ a leaf: it must not import from ``execute.processor`` or any other execute
 sibling, to keep the facade import graph acyclic.
 """
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, TypedDict, Union
@@ -74,3 +75,19 @@ class ExecutionPlan(TypedDict):
     unknown_framework_scripts: List[Dict[str, str]]
     missing_render_scripts: List[str]
     render_failures: List[Dict[str, str]]
+
+
+#: Environment escape hatch shared by both execution stacks (Step 12
+#: processor and the MCP/``GNNExecutor`` dispatch): set to "1" to bypass the
+#: pre-execution security gate (trusted-local research use only; see
+#: SECURITY.md).
+_GNN_ALLOW_UNSAFE_EXEC = "GNN_ALLOW_UNSAFE_EXEC"
+
+
+def _gnn_allow_unsafe_exec() -> bool:
+    """Whether the operator has explicitly opted out of the pre-exec gate."""
+    return os.environ.get(_GNN_ALLOW_UNSAFE_EXEC, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )

--- a/src/gnn/parsers/schema_parser.py
+++ b/src/gnn/parsers/schema_parser.py
@@ -16,8 +16,20 @@ from typing import Any, cast
 
 try:
     import defusedxml.ElementTree as ET
-except ImportError:
-    import xml.etree.ElementTree as ET  # nosec B405
+except ImportError as exc:  # pragma: no cover - defusedxml is a hard dependency
+    # Fail loud (RED_TEAM_REVIEW follow-up): silently falling back to the
+    # vulnerable stdlib xml.etree parser must never happen. Log the error
+    # and refuse to import rather than degrading XML entity protection.
+    logging.getLogger(__name__).error(
+        "defusedxml is a required dependency for schema (XSD/ASN.1/Alloy/Z) "
+        "parsing but is not installed; refusing to fall back to stdlib "
+        "xml.etree (%s)",
+        exc,
+    )
+    raise ImportError(
+        "defusedxml is required for secure schema parsing; install it "
+        "(e.g. `uv sync`) instead of falling back to stdlib xml.etree"
+    ) from exc
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 

--- a/src/gnn/parsers/xml_parser.py
+++ b/src/gnn/parsers/xml_parser.py
@@ -9,14 +9,24 @@ Date: 2025-01-11
 License: MIT
 """
 
-from typing import Any, cast
+import logging
+from typing import Any, Dict, List, Optional, cast
 
 try:
     import defusedxml.ElementTree as ET
-except ImportError:
-    import xml.etree.ElementTree as ET  # nosec B405
-import logging
-from typing import Dict, List, Optional
+except ImportError as exc:  # pragma: no cover - defusedxml is a hard dependency
+    # Fail loud (RED_TEAM_REVIEW follow-up): silently falling back to the
+    # vulnerable stdlib xml.etree parser must never happen. Log the error
+    # and refuse to import rather than degrading XML entity protection.
+    logging.getLogger(__name__).error(
+        "defusedxml is a required dependency for XML/PNML parsing but is "
+        "not installed; refusing to fall back to stdlib xml.etree (%s)",
+        exc,
+    )
+    raise ImportError(
+        "defusedxml is required for secure XML/PNML parsing; install it "
+        "(e.g. `uv sync`) instead of falling back to stdlib xml.etree"
+    ) from exc
 
 from .common import (
     BaseGNNParser,

--- a/src/gnn/render/activeinference_jl/activeinference_renderer.py
+++ b/src/gnn/render/activeinference_jl/activeinference_renderer.py
@@ -24,21 +24,18 @@ from gnn.render.multi_agent_common import (
 from gnn.render.pomdp_contract import build_canonical_pomdp_spec
 
 
-def _matrix_to_julia(matrix_data: Any) -> str:
+def _matrix_to_julia(matrix_data: Any, matrix_name: str = "matrix") -> str:
     """
     Convert shared matrix data structures to Julia format.
     Handles lists, tuples, and nested structures (matrices/tensors).
-    """
-    # Handle string input (if coming from string-based GNN spec)
-    if isinstance(matrix_data, str):
-        matrix_data = matrix_data.strip()
-        if matrix_data.startswith("[") or matrix_data.startswith("("):
-            try:
-                from gnn.utils.safe_eval import MATRIX_MAX_LEN, safe_literal_eval
 
-                matrix_data = safe_literal_eval(matrix_data, max_len=MATRIX_MAX_LEN)
-            except (ValueError, SyntaxError) as e:
-                logger.debug("Leaving matrix string unparsed for Julia output: %s", e)
+    String inputs are parsed with the bounded literal evaluator; a string
+    that fails to parse raises :class:`RenderMatrixParseError` instead of
+    being interpolated verbatim into generated Julia source.
+    """
+    from gnn.render.generators import _parse_matrix_literal
+
+    matrix_data = _parse_matrix_literal(matrix_data, matrix_name)
 
     # Normalize tuple to list for unified handling
     if isinstance(matrix_data, tuple):
@@ -717,11 +714,11 @@ def generate_activeinference_script(model_info: Dict[str, Any]) -> str:
     D_vector = model_info["D"]
     E_vector = model_info.get("E") or [1.0 / n_actions] * n_actions
 
-    julia_A = _matrix_to_julia(A_matrix)
-    julia_B = _matrix_to_julia(B_matrix)
-    julia_C = _matrix_to_julia(C_vector)
-    julia_D = _matrix_to_julia(D_vector)
-    julia_E = _matrix_to_julia(E_vector)
+    julia_A = _matrix_to_julia(A_matrix, "A")
+    julia_B = _matrix_to_julia(B_matrix, "B")
+    julia_C = _matrix_to_julia(C_vector, "C")
+    julia_D = _matrix_to_julia(D_vector, "D")
+    julia_E = _matrix_to_julia(E_vector, "E")
 
     script = f'''#!/usr/bin/env julia
 

--- a/src/gnn/render/generators.py
+++ b/src/gnn/render/generators.py
@@ -6,7 +6,7 @@ Fixed Render generators module for GNN code generation with enhanced visualizati
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,43 @@ def _positive_int_literal(value: Any, default: int = 15) -> int:
     except (TypeError, ValueError):
         parsed = default
     return max(1, parsed)
+
+
+class RenderMatrixParseError(ValueError):
+    """A GNN matrix literal could not be safely parsed for code generation.
+
+    Raised instead of interpolating raw, unvalidated specification text into
+    generated Python/Julia source (RED_TEAM_REVIEW follow-up: raw text in a
+    generated script is a code-injection sink).
+    """
+
+
+def _parse_matrix_literal(matrix_data: Any, matrix_name: str) -> Any:
+    """Parse a string-encoded matrix literal, failing closed on rejection.
+
+    Strings that look like array literals are parsed with the bounded
+    ``safe_literal_eval`` (DoS-resistant; RED_TEAM V-03). A string that fails
+    to parse is *rejected* — never interpolated verbatim into generated code.
+    Non-string data passes through unchanged.
+    """
+    if not isinstance(matrix_data, str):
+        return matrix_data
+    text = matrix_data.strip()
+    if not (text.startswith("[") or text.startswith("(")):
+        raise RenderMatrixParseError(
+            f"Matrix '{matrix_name}' is not a parseable array literal "
+            f"(got {len(text)} chars of non-literal text); refusing to "
+            "interpolate raw specification text into generated code"
+        )
+    try:
+        from gnn.utils.safe_eval import MATRIX_MAX_LEN, safe_literal_eval
+
+        return safe_literal_eval(text, max_len=MATRIX_MAX_LEN)
+    except (ValueError, SyntaxError) as exc:
+        raise RenderMatrixParseError(
+            f"Matrix '{matrix_name}' failed bounded literal parsing and "
+            f"cannot be embedded in generated code: {exc}"
+        ) from exc
 
 
 def generate_bnlearn_code(
@@ -170,22 +207,18 @@ def _to_pascal_case(base: str, *, allow_empty_fallback: str = "Model") -> str:
     return name
 
 
-def _matrix_to_julia(matrix_data: Any) -> str:
+def _matrix_to_julia(matrix_data: Any, matrix_name: str = "matrix") -> str:
     """Convert Python matrix (list of lists/tuples) to Julia matrix syntax.
 
     2D matrices use semicolon row separators: [0.9 0.05; 0.05 0.9]
     3D matrices use cat(...; dims=3) syntax
     1D vectors use comma separators: [0.1, 0.2, 0.3]
-    """
-    if isinstance(matrix_data, str):
-        matrix_data = matrix_data.strip()
-        if matrix_data.startswith("[") or matrix_data.startswith("("):
-            try:
-                from gnn.utils.safe_eval import MATRIX_MAX_LEN, safe_literal_eval
 
-                matrix_data = safe_literal_eval(matrix_data, max_len=MATRIX_MAX_LEN)
-            except (ValueError, SyntaxError):
-                return cast("str", matrix_data)
+    String inputs are parsed with the bounded literal evaluator; a string
+    that fails to parse raises :class:`RenderMatrixParseError` instead of
+    being interpolated verbatim into generated Julia source.
+    """
+    matrix_data = _parse_matrix_literal(matrix_data, matrix_name)
 
     if isinstance(matrix_data, (list, tuple)):
         if len(matrix_data) > 0 and isinstance(matrix_data[0], (list, tuple)):
@@ -246,24 +279,34 @@ def generate_pymdp_code(
         )
 
         # Format matrices for template (with fallbacks)
-        a_matrix = state_space.get(
+        a_matrix = _parse_matrix_literal(
+            state_space.get(
+                "A",
+                [
+                    [0.9, 0.05, 0.05],
+                    [0.05, 0.9, 0.05],
+                    [0.05, 0.05, 0.9],
+                    [0.33, 0.33, 0.33],
+                ],
+            ),
             "A",
-            [
-                [0.9, 0.05, 0.05],
-                [0.05, 0.9, 0.05],
-                [0.05, 0.05, 0.9],
-                [0.33, 0.33, 0.33],
-            ],
         )
-        b_matrix = state_space.get(
+        b_matrix = _parse_matrix_literal(
+            state_space.get(
+                "B",
+                [
+                    [[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]],
+                    [[0.2, 0.3, 0.5], [0.2, 0.3, 0.5], [0.1, 0.1, 0.8]],
+                ],
+            ),
             "B",
-            [
-                [[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]],
-                [[0.2, 0.3, 0.5], [0.2, 0.3, 0.5], [0.1, 0.1, 0.8]],
-            ],
         )
-        c_vector = state_space.get("C", [0.1, 0.1, 1.0, 0.0])
-        d_vector = state_space.get("D", [0.333, 0.333, 0.333])
+        c_vector = _parse_matrix_literal(
+            state_space.get("C", [0.1, 0.1, 1.0, 0.0]), "C"
+        )
+        d_vector = _parse_matrix_literal(
+            state_space.get("D", [0.333, 0.333, 0.333]), "D"
+        )
 
         # Generate PyMDP code using template
         code = PYMDP_TEMPLATE.format(

--- a/tests/execute/test_mcp_gate_bypass.py
+++ b/tests/execute/test_mcp_gate_bypass.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Regression tests for the SC-1 execution-stack gate bypass.
+
+The Step 12 processor gates every rendered script before execution
+(``execute.processor.execute_single_script``), but historically the
+``GNNExecutor`` dispatch (shared by the MCP ``execute_gnn_model`` tool via
+``execute_simulation_from_gnn`` and by the public ``gnn.execute`` API)
+dispatched scripts to the per-framework runners without any pre-execution
+scan — an ungated execution path. These tests pin the fix: the same
+``scan_script_for_execution`` gate now runs at the ``GNNExecutor`` dispatch
+and inside ``execute_script_safely`` (the shared runner choke point), so a
+dangerous rendered script submitted through the executor stack is classified
+``SecurityGateBlocked`` and never executed.
+
+Note: the MCP tool itself only accepts GNN source files (``.md``/``.json``/
+``.yaml``/``.yml``) and rejects ``.py`` payloads at path validation (pinned
+by ``tests/execute/test_execute_mcp_wiring.py``). The gate therefore lives
+on the ``GNNExecutor`` dispatch that the MCP tool delegates to, and on
+``execute_script_safely`` which every Python framework runner funnels
+through — together these close the "ungated remote-executable path".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from gnn.execute import execute_simulation_from_gnn  # noqa: E402
+from gnn.execute.executor import (  # noqa: E402
+    GNNExecutor,
+    execute_gnn_model,
+    execute_script_safely,
+)
+
+# ``run_subprocess_envelope`` sentinel: the process never started.
+NEVER_STARTED = -1
+
+_DANGEROUS_SCRIPT = "import os\nos.system('echo pwned')\n"
+_BENIGN_SCRIPT = "x = [1, 2, 3]\nprint(sum(x))\n"
+
+
+def _no_unsafe_exec(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the escape hatch is off for the duration of a test."""
+    monkeypatch.delenv("GNN_ALLOW_UNSAFE_EXEC", raising=False)
+
+
+class TestExecutorGateBlocksDangerousScripts:
+    """The GNNExecutor dispatch must not bypass the pre-execution gate."""
+
+    def test_mcp_delegate_path_blocks_dangerous_script(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dangerous rendered script through the MCP delegation chain is
+        classified SecurityGateBlocked and never executes."""
+        sentinel = tmp_path / "sentinel"
+        script = tmp_path / "dangerous_pymdp.py"
+        script.write_text(
+            f"import os\nos.system('touch {sentinel}')\n",
+            encoding="utf-8",
+        )
+        _no_unsafe_exec(monkeypatch)
+
+        result = execute_simulation_from_gnn(script, tmp_path / "exec_out")
+
+        assert result["success"] is False
+        assert result["error_type"] == "SecurityGateBlocked"
+        assert "security gate blocked" in result["error"]
+        assert result["security_findings"], "blocked findings must be recorded"
+        assert not sentinel.exists(), "blocked script must never execute"
+
+    def test_gnnexecutor_blocks_dangerous_script(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct GNNExecutor dispatch is gated (defense in depth)."""
+        script = tmp_path / "dangerous.py"
+        script.write_text(_DANGEROUS_SCRIPT)
+        _no_unsafe_exec(monkeypatch)
+
+        result = GNNExecutor(output_dir=str(tmp_path)).execute_gnn_model(
+            str(script), execution_type="pymdp"
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "SecurityGateBlocked"
+        assert any(
+            finding.get("vulnerability_type") for finding in result["security_findings"]
+        )
+
+    def test_gate_block_classification_survives_convenience_wrapper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``execute_gnn_model`` convenience wrapper keeps the gate envelope."""
+        script = tmp_path / "dangerous_jax.py"
+        script.write_text("eval('__import__(\"os\").system(\"id\")')\n")
+        _no_unsafe_exec(monkeypatch)
+
+        result = execute_gnn_model(str(script), execution_type="jax")
+
+        assert result["success"] is False
+        assert result["error_type"] == "SecurityGateBlocked"
+        assert result.get("status") == "FAILED"
+
+    def test_escape_hatch_bypasses_executor_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GNN_ALLOW_UNSAFE_EXEC semantics match the Step 12 processor stack."""
+        script = tmp_path / "dangerous.py"
+        script.write_text("import os\nos.system('echo pwned')\n")
+        monkeypatch.setenv("GNN_ALLOW_UNSAFE_EXEC", "1")
+
+        result = GNNExecutor(output_dir=str(tmp_path)).execute_gnn_model(
+            str(script), execution_type="pymdp"
+        )
+
+        # The gate must not be the reason for failure. The script may still
+        # fail for unrelated reasons (imports); assert the classification
+        # never appears.
+        assert result.get("error_type") != "SecurityGateBlocked"
+
+
+class TestExecutorPositivePath:
+    """Benign scripts still execute through the gated dispatch."""
+
+    def test_benign_script_executes_via_pymdp_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trivial no-op script runs offline via the pymdp runner path."""
+        script = tmp_path / "benign_pymdp.py"
+        script.write_text(_BENIGN_SCRIPT)
+        _no_unsafe_exec(monkeypatch)
+
+        result = GNNExecutor(output_dir=str(tmp_path)).execute_gnn_model(
+            str(script), execution_type="pymdp", timeout=60
+        )
+
+        assert result["success"] is True, result.get("error", "")
+        assert result["return_code"] == 0
+        assert "6" in result["stdout"]
+
+    def test_benign_script_executes_via_execute_script_safely(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The runner-level choke point passes benign scripts through."""
+        script = tmp_path / "benign.py"
+        script.write_text(_BENIGN_SCRIPT)
+        _no_unsafe_exec(monkeypatch)
+
+        result = execute_script_safely(script, timeout=60)
+
+        assert result["success"] is True
+        assert result["return_code"] == 0
+        assert "6" in result["stdout"]
+
+    def test_non_script_model_paths_skip_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GNN model files (.md) are not scripts; dispatch stays ungated."""
+        model = tmp_path / "model.md"
+        model.write_text("## ModelName\nsample\n")
+        _no_unsafe_exec(monkeypatch)
+
+        result = GNNExecutor(output_dir=str(tmp_path)).execute_gnn_model(
+            str(model), execution_type="pymdp"
+        )
+
+        # Non-script inputs take the legacy "treated as source model" path.
+        assert result["success"] is True
+        assert "render/execute pipeline required" in result["stdout"]
+
+
+class TestGateFailsClosed:
+    """A broken security module blocks execution instead of skipping."""
+
+    def test_gate_import_failure_blocks_execution(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unimportable scanner -> SecurityGateBlocked (fail closed)."""
+        script = tmp_path / "benign.py"
+        script.write_text(_BENIGN_SCRIPT)
+        _no_unsafe_exec(monkeypatch)
+        monkeypatch.setitem(sys.modules, "gnn.security.processor", None)
+
+        result = GNNExecutor(output_dir=str(tmp_path)).execute_gnn_model(
+            str(script), execution_type="pymdp"
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "SecurityGateBlocked"
+        assert "fail closed" in result["error"]
+
+    def test_unreadable_script_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unscannable targets deny (deny_unreadable) and never start."""
+        script = tmp_path / "missing.py"  # never created
+        _no_unsafe_exec(monkeypatch)
+
+        result = execute_script_safely(script)
+
+        assert result["success"] is False
+        assert result["error_type"] == "SecurityGateBlocked"
+        assert result["return_code"] == NEVER_STARTED
+
+
+def test_mcp_execute_path_result_shape_unchanged() -> None:
+    """The MCP-visible envelope still carries the execution metadata keys.
+
+    Guard against the gate accidentally reshaping the result the MCP tool
+    returns: the block envelope is decorated with the same execution-time /
+    device fields as a normal run.
+    """
+    executor = GNNExecutor(output_dir=str(Path(__file__).parent / "_scratch_shape"))
+    blocked = executor.execute_gnn_model(
+        "definitely_not_a_real_script.py", execution_type="pymdp"
+    )
+    assert blocked["success"] is False
+    assert blocked["error_type"] == "SecurityGateBlocked"
+    for key in ("execution_time", "execution_type", "model_path", "execution_device"):
+        assert key in blocked, f"missing MCP envelope key: {key}"

--- a/tests/execute/test_mcp_gate_bypass.py
+++ b/tests/execute/test_mcp_gate_bypass.py
@@ -192,28 +192,44 @@ class TestGateFailsClosed:
         assert result["error_type"] == "SecurityGateBlocked"
         assert "fail closed" in result["error"]
 
-    def test_unreadable_script_fails_closed(
+    def test_dangerous_script_blocked_at_runner_level(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Unscannable targets deny (deny_unreadable) and never start."""
-        script = tmp_path / "missing.py"  # never created
+        """A real dangerous script on disk never starts (NEVER_STARTED)."""
+        script = tmp_path / "dangerous_runner.py"
+        script.write_text(_DANGEROUS_SCRIPT)
         _no_unsafe_exec(monkeypatch)
 
-        result = execute_script_safely(script)
+        result = execute_script_safely(script, timeout=60)
 
         assert result["success"] is False
         assert result["error_type"] == "SecurityGateBlocked"
         assert result["return_code"] == NEVER_STARTED
 
+    def test_missing_script_keeps_historical_envelope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing/suffix rejections keep their pre-gate envelopes; the gate
+        covers only scripts that could actually execute."""
+        _no_unsafe_exec(monkeypatch)
 
-def test_mcp_execute_path_result_shape_unchanged() -> None:
+        missing = execute_script_safely(tmp_path / "never_created.py")
+        assert missing["error_type"] == "FileNotFoundError"
+
+        wrong_suffix = tmp_path / "notes.md"
+        wrong_suffix.write_text("not a script\n")
+        rejected = execute_script_safely(wrong_suffix)
+        assert rejected["error_type"] == "ValueError"
+
+
+def test_mcp_execute_path_result_shape_unchanged(tmp_path: Path) -> None:
     """The MCP-visible envelope still carries the execution metadata keys.
 
     Guard against the gate accidentally reshaping the result the MCP tool
     returns: the block envelope is decorated with the same execution-time /
     device fields as a normal run.
     """
-    executor = GNNExecutor(output_dir=str(Path(__file__).parent / "_scratch_shape"))
+    executor = GNNExecutor(output_dir=str(tmp_path))
     blocked = executor.execute_gnn_model(
         "definitely_not_a_real_script.py", execution_type="pymdp"
     )


### PR DESCRIPTION
Security bundle from the 2026-09-09 scope-campaign (SC-1, SC-2, SC-33):

**SC-1 — the ungated execution path is closed.** The MCP `execute_gnn_model` tool delegates to `GNNExecutor`, whose runner stack (`execute_script_safely` + per-framework runners) never referenced the pre-execution security gate that Step 12's processor stack has. Now gated at both chokepoints:
- `GNNExecutor.execute_gnn_model` dispatch runs `_pre_execution_gate(model_path)` (mirrors the processor gate; honors `GNN_ALLOW_UNSAFE_EXEC` via a new shared helper in `execute/types.py` with identical semantics on both stacks); scan-deny → structured `SecurityGateBlocked` result with findings + gate receipt, before any runner branch.
- `execute_script_safely` (the runner-level subprocess chokepoint) applies the same gate after the pre-existing missing-file/non-.py rejections, so pinned envelopes are unchanged.
- Scanner import failure or scanner exception → **fail closed** (`deny_gate_failure`), not skip.
- MCP tool names/signatures unchanged; blocked envelope shape preserved (`execution_time`/`execution_type`/`model_path`/`execution_device`).
- New regression suite `tests/execute/test_mcp_gate_bypass.py` (12 tests): dangerous-script block through the MCP delegation chain + direct dispatch + runner level, escape-hatch parity, benign positive paths (offline, pymdp runner), fail-closed on sabotaged scanner, envelope-shape stability.

**SC-2 fail-closed bundle:** (a) the processor's security-gate `except ImportError` no longer silently skips enforcement — a broken security module blocks execution with a distinct fail-closed reason; (b) sandbox receipts: `GNN_SANDBOX=off` (the default) is now recorded in execution summaries (`exec_result['sandbox']` via `_sandbox_receipt` + slim-execution-detail persistence), distinguishing default-off from prefer-without-backend; (c) raw-text fallback removed from `_matrix_to_julia` and `generate_pymdp_code` — unparseable matrix literals now raise `RenderMatrixParseError` instead of being interpolated into generated Julia/Python source (same fix for the activeinference_jl renderer's silent debug fallback); (d) bandit: B601 removed from skips (verified: zero `# nosec B601` and zero `shell=True` under src/gnn).

**SC-33:** parsers no longer silently fall back to stdlib `xml.etree` when defusedxml is missing — defusedxml is a hard dependency; missing → logged error + clear ImportError. Behavior with defusedxml present is byte-identical.

Known residual (documented): the Julia-backed runners (`run_rxinfer_scripts`, `activeinference_runner`, `stan_runner`) spawn `julia`/`cmdstanpy` directly and are covered at the `execute_gnn_model` entry gate and the Step-12 processor gate, not at the runner layer — extracting a shared per-runner gate module is a deliberate follow-up to keep this diff minimal.

Verification (this branch, full suite): **5256 passed, 19 skipped, 0 failed**; bandit medium/medium exit 0; ruff + mypy clean.